### PR TITLE
Implement real Google Sheets read via gspread in ask_google_sheets

### DIFF
--- a/backend/app/scripts/ask_google_sheets.py
+++ b/backend/app/scripts/ask_google_sheets.py
@@ -4,9 +4,62 @@ Requires Google service account credentials in an environment variable.
 Replaces ask-question-google-sheets (no Langflow).
 """
 from typing import Any
+import asyncio
 import json
 import os
 import re
+import sqlite3
+
+MAX_SHEET_ROWS = 10_000
+
+
+def _get_gspread_client(credentials_json: str):
+    """Build gspread client from service account JSON string."""
+    import gspread
+
+    creds_dict = json.loads(credentials_json)
+    return gspread.service_account_from_dict(creds_dict)
+
+
+def _fetch_sheet_data_sync(
+    client, spreadsheet_id: str, sheet_name: str, max_rows: int = MAX_SHEET_ROWS
+) -> tuple[list[str], list[dict]]:
+    """
+    Fetch rows from a Google Sheet.
+    Returns (columns, rows) where rows is a list of dicts (up to max_rows data rows).
+    """
+    spreadsheet = client.open_by_key(spreadsheet_id)
+    worksheet = spreadsheet.worksheet(sheet_name)
+    all_values = worksheet.get_all_values()
+    if not all_values:
+        return [], []
+    header = [str(h) for h in all_values[0]]
+    rows = []
+    for row in all_values[1 : max_rows + 1]:
+        padded = list(row) + [""] * (len(header) - len(row))
+        rows.append(dict(zip(header, padded[: len(header)])))
+    return header, rows
+
+
+def _run_sql_on_rows(rows: list[dict], columns: list[str], query: str) -> list[dict]:
+    """Load sheet rows into an in-memory SQLite table named 'data' and execute a SELECT query."""
+    import pandas as pd
+
+    q = query.strip().upper()
+    if not q.startswith("SELECT"):
+        raise ValueError("Only SELECT queries are allowed")
+    for forbidden in ("DELETE", "UPDATE", "INSERT", "DROP", "ALTER", "TRUNCATE", "CREATE"):
+        if forbidden in q:
+            raise ValueError("Only SELECT queries are allowed")
+    df = pd.DataFrame(rows, columns=columns)
+    conn = sqlite3.connect(":memory:")
+    try:
+        df.to_sql("data", conn, index=False, if_exists="replace")
+        cur = conn.execute(query)
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, row)) for row in cur.fetchall()]
+    finally:
+        conn.close()
 
 
 async def ask_google_sheets(
@@ -29,21 +82,37 @@ async def ask_google_sheets(
     if not credentials_json:
         raise ValueError("GOOGLE_SHEETS_SERVICE_ACCOUNT not configured")
 
-    # Use gspread + google-auth here to read the sheet when implementing
+    from app.llm.charting import build_chart_input
     from app.llm.client import chat_completion
+    from app.llm.elaborate import elaborate_answer_with_results
     from app.llm.followups import refine_followup_questions
     from app.llm.logs import record_log
+    from app.scripts.sql_utils import extract_sql_from_field
 
-    # TODO: implement real sheet read (gspread)
+    loop = asyncio.get_event_loop()
+
+    # Fetch real sheet data via gspread
+    gspread_client = await loop.run_in_executor(None, lambda: _get_gspread_client(credentials_json))
+    columns, rows = await loop.run_in_executor(
+        None, lambda: _fetch_sheet_data_sync(gspread_client, spreadsheet_id, sheet_name)
+    )
+
+    if columns:
+        available_columns = available_columns or columns
     columns_text = ", ".join(available_columns or [])
-    schema_text = f"Spreadsheet: {spreadsheet_id}, sheet: {sheet_name}. Columns: {columns_text or 'unknown'}"
-    sample_json = "[]"
+    schema_text = (
+        f"Spreadsheet: {spreadsheet_id}, sheet: {sheet_name}. "
+        f"Columns: {columns_text or 'unknown'}. "
+        f"Total rows: {len(rows)}."
+    )
+    sample_json = json.dumps(rows[:5], ensure_ascii=False, default=str)
 
     system = (
         "You are an assistant that answers questions about Google Sheets data. "
         "Use only the context provided. "
         "If the question requires precise filtering or aggregation on the full sheet, you MUST provide a SQL query "
-        "(in a fenced ```sql``` block) that would answer it exactly. "
+        "(in a fenced ```sql``` block) that would answer it exactly using SELECT ... FROM data. "
+        "Quote column names with double quotes if they have spaces or special characters. "
         "In that case, also state that the answer requires executing the SQL on the full dataset. "
         "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), "
         "sqlQuery (string or null). "
@@ -61,7 +130,16 @@ async def ask_google_sheets(
         for turn in history[-5:]:
             messages.append({"role": "user", "content": turn["question"]})
             messages.append({"role": "assistant", "content": turn["answer"]})
-    messages.append({"role": "user", "content": f"Context: {schema_text}\nSample: {sample_json}\n\nQuestion: {question}"})
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                f"Context: {schema_text}\n"
+                f"Sample data (up to 5 rows): {sample_json}\n\n"
+                f"Question: {question}"
+            ),
+        }
+    )
     raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
     trace["stage"] = "pergunta_main"
     trace["source_type"] = "google_sheets"
@@ -78,6 +156,31 @@ async def ask_google_sheets(
     parsed = _parse_llm_json(raw_answer)
     answer = parsed["answer"]
     follow_up = parsed["followUpQuestions"]
+    sql_query = extract_sql_from_field(parsed.get("sqlQuery") or "")
+
+    # Execute SQL on the fetched sheet data and have LLM elaborate
+    chart_input = None
+    if sql_query and sql_query.upper().strip().startswith("SELECT") and rows:
+        try:
+            result_rows = await loop.run_in_executor(
+                None, lambda: _run_sql_on_rows(rows, columns, sql_query)
+            )
+            if result_rows is not None:
+                chart_input = build_chart_input(result_rows, schema_text)
+                elaborated = await elaborate_answer_with_results(
+                    question=question,
+                    query_results=result_rows,
+                    agent_description=agent_description,
+                    source_name=source_name,
+                    schema_text=schema_text,
+                    llm_overrides=llm_overrides,
+                    channel=channel,
+                )
+                answer = elaborated["answer"]
+                follow_up = elaborated["followUpQuestions"] or follow_up
+        except Exception as e:
+            answer = f"{answer}\n\n*Erro ao executar a consulta na planilha: {e}*"
+
     if not parsed["parsed_ok"]:
         if not answer:
             answer = raw_answer
@@ -90,7 +193,7 @@ async def ask_google_sheets(
         llm_overrides=llm_overrides,
         channel=channel,
     )
-    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_up, "chartInput": None}
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_up, "chartInput": chart_input}
 
 
 def _parse_llm_json(raw: str) -> dict[str, Any]:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,6 +29,6 @@ matplotlib==3.10.1
 
 # Optional: BigQuery, Google Sheets, SQL
 # google-cloud-bigquery==3.25.0
-# gspread==6.1.2
-# google-auth==2.36.0
+gspread==6.1.2
+google-auth==2.36.0
 # sqlalchemy (above) + drivers: pymysql, psycopg2-binary


### PR DESCRIPTION
Replace placeholder schema/sample data with actual sheet content fetched
using gspread. Adds _get_gspread_client and _fetch_sheet_data_sync helpers
(following the ask_bigquery pattern), SQL execution on fetched rows via
in-memory SQLite, chart input support, and answer elaboration when the LLM
returns a SQL query. Enables gspread and google-auth in requirements.txt.

https://claude.ai/code/session_01Ri5VhJy3VUKqozT4u5t95t