### PR TITLE
Add dbt and GitHub file data sources with LLM integration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.config import get_settings
 from app.database import engine, Base, AsyncSessionLocal
 from app.routers import auth_router, ask, crud, users_router, settings_router, bigquery_router, sql_router, summary_router, logs_router, audio_overview_router, telegram_router
 from app.routers import api_keys_router, public_api_router, whatsapp_router, audit_router, webhook_router, automl_router, report_router
+from app.routers import dbt_router, github_router
 from app.models import User
 from app.auth import hash_password, GUEST_USER_ID, ADMIN_USER_ID
 
@@ -228,6 +229,8 @@ app.include_router(webhook_router.router, prefix=prefix)
 app.include_router(automl_router.router, prefix=prefix)
 app.include_router(report_router.router, prefix=prefix)
 app.include_router(public_api_router.router)  # public API at /v1/ask (no internal prefix)
+app.include_router(dbt_router.router, prefix=prefix)
+app.include_router(github_router.router, prefix=prefix)
 
 
 @app.get(prefix + "/config")

--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -21,6 +21,8 @@ from app.models import User
 from app.schemas import AskQuestionRequest, AskQuestionResponse
 from app.scripts.ask_csv import ask_csv
 from app.scripts.ask_bigquery import ask_bigquery
+from app.scripts.ask_dbt import ask_dbt
+from app.scripts.ask_github_file import ask_github_file
 from app.scripts.ask_google_sheets import ask_google_sheets
 from app.scripts.ask_sql import ask_sql
 from app.scripts.ask_sql_multi import ask_sql_multi_source
@@ -267,6 +269,48 @@ async def ask_question(
             history=history,
             channel=channel,
             sql_mode=sql_mode,
+        )
+    elif source.type == "dbt":
+        meta = source.metadata_ or {}
+        result = await ask_dbt(
+            project_source=meta.get("projectSource", "github"),
+            connection_string=meta.get("connectionString", ""),
+            question=body.question,
+            agent_description=agent.description or "",
+            source_name=source.name,
+            github_token=meta.get("githubToken"),
+            github_repo=meta.get("githubRepo", ""),
+            github_branch=meta.get("githubBranch", "main"),
+            manifest_path=meta.get("manifestPath", "target/manifest.json"),
+            dbt_cloud_token=meta.get("dbtCloudToken"),
+            dbt_cloud_account_id=str(meta.get("dbtCloudAccountId", "")),
+            dbt_cloud_job_id=str(meta.get("dbtCloudJobId", "")),
+            selected_models=meta.get("selectedModels") or None,
+            table_infos=meta.get("table_infos"),
+            llm_overrides=llm_overrides,
+            history=history,
+            channel=channel,
+            sql_mode=sql_mode,
+        )
+    elif source.type == "github_file":
+        meta = source.metadata_ or {}
+        github_repo = meta.get("githubRepo", "")
+        file_path = meta.get("filePath", "")
+        if not github_repo or not file_path:
+            raise HTTPException(400, "GitHub file source missing githubRepo or filePath in metadata")
+        result = await ask_github_file(
+            github_repo=github_repo,
+            file_path=file_path,
+            question=body.question,
+            agent_description=agent.description or "",
+            source_name=source.name,
+            github_token=meta.get("githubToken"),
+            github_branch=meta.get("githubBranch", "main"),
+            columns=meta.get("columns"),
+            preview_rows=meta.get("preview_rows"),
+            llm_overrides=llm_overrides,
+            history=history,
+            channel=channel,
         )
     else:
         raise HTTPException(400, f"Unsupported source type: {source.type}")

--- a/backend/app/routers/dbt_router.py
+++ b/backend/app/routers/dbt_router.py
@@ -1,0 +1,130 @@
+"""
+dbt source discovery and metadata refresh.
+- Validate manifest (GitHub or dbt Cloud) and list available models
+- Refresh source metadata (table_infos from manifest)
+"""
+import json
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import require_user
+from app.database import get_db
+from app.models import Source, User
+from app.routers.crud import _sanitize_for_json
+
+router = APIRouter(prefix="/dbt", tags=["dbt"])
+
+
+@router.post("/validate-manifest")
+async def validate_manifest(
+    body: dict,
+    user: User = Depends(require_user),
+):
+    """
+    Validate dbt credentials and return list of models from manifest.json.
+
+    Body for GitHub source:
+      { "projectSource": "github", "githubToken": "...", "githubRepo": "owner/repo",
+        "githubBranch": "main", "manifestPath": "target/manifest.json" }
+
+    Body for dbt Cloud source:
+      { "projectSource": "cloud", "dbtCloudToken": "...",
+        "dbtCloudAccountId": "123", "dbtCloudJobId": "456" }
+    """
+    from app.scripts.ask_dbt import (
+        _fetch_manifest_from_github,
+        _fetch_manifest_from_dbt_cloud,
+        _extract_table_infos_from_manifest,
+    )
+
+    project_source = (body.get("projectSource") or "").strip()
+    if project_source not in ("github", "cloud"):
+        raise HTTPException(400, "projectSource must be 'github' or 'cloud'")
+
+    try:
+        if project_source == "github":
+            github_repo = (body.get("githubRepo") or "").strip()
+            if not github_repo:
+                raise HTTPException(400, "githubRepo is required")
+            manifest = await _fetch_manifest_from_github(
+                token=body.get("githubToken"),
+                repo=github_repo,
+                branch=(body.get("githubBranch") or "main").strip(),
+                manifest_path=(body.get("manifestPath") or "target/manifest.json").strip(),
+            )
+        else:
+            dbt_cloud_token = (body.get("dbtCloudToken") or "").strip()
+            dbt_cloud_account_id = str(body.get("dbtCloudAccountId") or "").strip()
+            dbt_cloud_job_id = str(body.get("dbtCloudJobId") or "").strip()
+            if not dbt_cloud_token or not dbt_cloud_account_id or not dbt_cloud_job_id:
+                raise HTTPException(400, "dbtCloudToken, dbtCloudAccountId and dbtCloudJobId are required")
+            manifest = await _fetch_manifest_from_dbt_cloud(
+                token=dbt_cloud_token,
+                account_id=dbt_cloud_account_id,
+                job_id=dbt_cloud_job_id,
+            )
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except Exception as e:
+        raise HTTPException(400, f"Failed to fetch manifest: {e}")
+
+    table_infos = _extract_table_infos_from_manifest(manifest)
+    models = [
+        {"name": t["table"], "columns": t.get("columns", []), "description": t.get("description", "")}
+        for t in table_infos
+    ]
+    return {"models": models, "total": len(models)}
+
+
+@router.post("/sources/{source_id}/refresh-metadata")
+async def refresh_source_metadata(
+    source_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    """Re-fetch manifest and update table_infos for the source."""
+    from app.scripts.ask_dbt import (
+        _fetch_manifest_from_github,
+        _fetch_manifest_from_dbt_cloud,
+        _extract_table_infos_from_manifest,
+    )
+
+    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    source = r.scalar_one_or_none()
+    if not source:
+        raise HTTPException(404, "Source not found")
+    if source.type != "dbt":
+        raise HTTPException(400, "Source is not a dbt source")
+
+    meta = dict(source.metadata_ or {})
+    project_source = meta.get("projectSource", "")
+
+    try:
+        if project_source == "github":
+            manifest = await _fetch_manifest_from_github(
+                token=meta.get("githubToken"),
+                repo=meta.get("githubRepo", ""),
+                branch=meta.get("githubBranch", "main"),
+                manifest_path=meta.get("manifestPath", "target/manifest.json"),
+            )
+        elif project_source == "cloud":
+            manifest = await _fetch_manifest_from_dbt_cloud(
+                token=meta.get("dbtCloudToken", ""),
+                account_id=str(meta.get("dbtCloudAccountId", "")),
+                job_id=str(meta.get("dbtCloudJobId", "")),
+            )
+        else:
+            raise HTTPException(400, f"Unknown projectSource: '{project_source}'")
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except Exception as e:
+        raise HTTPException(400, f"Failed to fetch manifest: {e}")
+
+    selected_models = meta.get("selectedModels") or []
+    table_infos = _extract_table_infos_from_manifest(manifest, selected_models or None)
+    meta["table_infos"] = table_infos
+    source.metadata_ = _sanitize_for_json(meta)
+    await db.commit()
+    await db.refresh(source)
+    return {"metaJSON": source.metadata_, "modelCount": len(table_infos)}

--- a/backend/app/routers/github_router.py
+++ b/backend/app/routers/github_router.py
@@ -1,0 +1,154 @@
+"""
+GitHub file source discovery and metadata refresh.
+- Validate repository access and parse a data file (CSV/TSV/JSON)
+- List data files in a repository path
+- Refresh source metadata (columns, preview_rows)
+"""
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import require_user
+from app.database import get_db
+from app.models import Source, User
+from app.routers.crud import _sanitize_for_json
+
+router = APIRouter(prefix="/github", tags=["github"])
+
+_SUPPORTED_EXTENSIONS = {".csv", ".tsv", ".json", ".jsonl", ".ndjson"}
+
+
+@router.post("/validate")
+async def validate_github_file(
+    body: dict,
+    user: User = Depends(require_user),
+):
+    """
+    Validate access to a GitHub repo file and return columns + preview rows.
+
+    Body: { "githubToken": "...", "githubRepo": "owner/repo",
+            "githubBranch": "main", "filePath": "data/sales.csv" }
+    """
+    from app.scripts.ask_github_file import _download_github_file, _parse_file_content
+
+    github_repo = (body.get("githubRepo") or "").strip()
+    file_path = (body.get("filePath") or "").strip()
+    if not github_repo:
+        raise HTTPException(400, "githubRepo is required")
+    if not file_path:
+        raise HTTPException(400, "filePath is required")
+
+    try:
+        content = await _download_github_file(
+            token=body.get("githubToken"),
+            repo=github_repo,
+            branch=(body.get("githubBranch") or "main").strip(),
+            file_path=file_path,
+        )
+        df = _parse_file_content(content, file_path)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except Exception as e:
+        raise HTTPException(400, f"Failed to read file: {e}")
+
+    columns = list(df.columns)
+    preview_rows = df.head(5).to_dict(orient="records")
+    return {
+        "columns": columns,
+        "previewRows": preview_rows,
+        "rowCount": len(df),
+    }
+
+
+@router.post("/list-files")
+async def list_github_files(
+    body: dict,
+    user: User = Depends(require_user),
+):
+    """
+    List data files (CSV/TSV/JSON) in a repository directory.
+
+    Body: { "githubToken": "...", "githubRepo": "owner/repo",
+            "githubBranch": "main", "dirPath": "data" }
+    """
+    github_repo = (body.get("githubRepo") or "").strip()
+    dir_path = (body.get("dirPath") or "").strip().strip("/")
+    if not github_repo:
+        raise HTTPException(400, "githubRepo is required")
+
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    token = body.get("githubToken")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    branch = (body.get("githubBranch") or "main").strip()
+    url = f"https://api.github.com/repos/{github_repo}/contents/{dir_path}?ref={branch}"
+
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            resp = await client.get(url, headers=headers)
+    except Exception as e:
+        raise HTTPException(400, f"GitHub request failed: {e}")
+
+    if resp.status_code == 401:
+        raise HTTPException(400, "GitHub authentication failed. Check the token.")
+    if resp.status_code == 404:
+        raise HTTPException(400, f"Path '{dir_path}' not found in {github_repo}@{branch}.")
+    if resp.status_code != 200:
+        raise HTTPException(400, f"GitHub API error {resp.status_code}: {resp.text[:200]}")
+
+    items = resp.json()
+    if not isinstance(items, list):
+        raise HTTPException(400, "Path points to a file, not a directory.")
+
+    files = [
+        {"name": item["name"], "path": item["path"], "size": item.get("size", 0)}
+        for item in items
+        if item.get("type") == "file"
+        and any(item["name"].lower().endswith(ext) for ext in _SUPPORTED_EXTENSIONS)
+    ]
+    return {"files": files}
+
+
+@router.post("/sources/{source_id}/refresh-metadata")
+async def refresh_source_metadata(
+    source_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    """Re-download the file and update columns + preview_rows for the source."""
+    from app.scripts.ask_github_file import _download_github_file, _parse_file_content
+
+    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    source = r.scalar_one_or_none()
+    if not source:
+        raise HTTPException(404, "Source not found")
+    if source.type != "github_file":
+        raise HTTPException(400, "Source is not a GitHub file source")
+
+    meta = dict(source.metadata_ or {})
+    github_repo = meta.get("githubRepo", "")
+    file_path = meta.get("filePath", "")
+    if not github_repo or not file_path:
+        raise HTTPException(400, "Source missing githubRepo or filePath")
+
+    try:
+        content = await _download_github_file(
+            token=meta.get("githubToken"),
+            repo=github_repo,
+            branch=meta.get("githubBranch", "main"),
+            file_path=file_path,
+        )
+        df = _parse_file_content(content, file_path)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except Exception as e:
+        raise HTTPException(400, f"Failed to refresh file: {e}")
+
+    meta["columns"] = list(df.columns)
+    meta["preview_rows"] = df.head(10).to_dict(orient="records")
+    meta["row_count"] = len(df)
+    source.metadata_ = _sanitize_for_json(meta)
+    await db.commit()
+    await db.refresh(source)
+    return {"metaJSON": source.metadata_}

--- a/backend/app/scripts/ask_dbt.py
+++ b/backend/app/scripts/ask_dbt.py
@@ -1,0 +1,187 @@
+"""
+Answer questions about dbt project models using an LLM.
+
+Supports two manifest sources:
+  - "github": fetches manifest.json from a GitHub repository via API
+  - "cloud":  fetches the latest artifact from dbt Cloud API
+
+After resolving the manifest, delegates query execution to ask_sql logic.
+"""
+from typing import Any
+import asyncio
+import base64
+import json
+import httpx
+
+
+async def _fetch_manifest_from_github(
+    token: str | None,
+    repo: str,
+    branch: str,
+    manifest_path: str,
+) -> dict:
+    """Download and parse manifest.json from a GitHub repository."""
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    url = f"https://api.github.com/repos/{repo}/contents/{manifest_path}?ref={branch}"
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(url, headers=headers)
+    if resp.status_code == 401:
+        raise ValueError("GitHub authentication failed. Check the token.")
+    if resp.status_code == 404:
+        raise ValueError(f"manifest.json not found at '{manifest_path}' in {repo}@{branch}.")
+    if resp.status_code != 200:
+        raise ValueError(f"GitHub API error {resp.status_code}: {resp.text[:200]}")
+    data = resp.json()
+    encoding = data.get("encoding", "")
+    content = data.get("content", "")
+    if encoding == "base64":
+        raw = base64.b64decode(content).decode("utf-8")
+    else:
+        raw = content
+    return json.loads(raw)
+
+
+async def _fetch_manifest_from_dbt_cloud(
+    token: str,
+    account_id: str,
+    job_id: str,
+) -> dict:
+    """Download manifest.json artifact from the latest completed dbt Cloud run for a job."""
+    headers = {"Authorization": f"Token {token}"}
+    base = "https://cloud.getdbt.com/api/v2"
+    # Find latest completed run for job
+    runs_url = f"{base}/accounts/{account_id}/runs/?job_definition_id={job_id}&order_by=-finished_at&limit=1"
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(runs_url, headers=headers)
+    if resp.status_code == 401:
+        raise ValueError("dbt Cloud authentication failed. Check the service token.")
+    if resp.status_code != 200:
+        raise ValueError(f"dbt Cloud API error {resp.status_code}: {resp.text[:200]}")
+    runs_data = resp.json()
+    runs = runs_data.get("data", [])
+    if not runs:
+        raise ValueError(f"No completed runs found for job {job_id}.")
+    run_id = runs[0]["id"]
+    # Fetch manifest artifact
+    artifact_url = f"{base}/accounts/{account_id}/runs/{run_id}/artifacts/manifest.json"
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(artifact_url, headers=headers)
+    if resp.status_code != 200:
+        raise ValueError(f"dbt Cloud artifact error {resp.status_code}: {resp.text[:200]}")
+    return resp.json()
+
+
+def _extract_table_infos_from_manifest(
+    manifest: dict,
+    selected_models: list[str] | None = None,
+) -> list[dict]:
+    """
+    Parse dbt manifest nodes to build table_infos compatible with ask_sql.
+
+    Returns [{"table": "model_name", "columns": ["col1", ...], "description": "..."}]
+    """
+    nodes = manifest.get("nodes", {})
+    sources = manifest.get("sources", {})
+    table_infos: list[dict] = []
+
+    def _columns_from_node(node: dict) -> list[str]:
+        raw = node.get("columns", {})
+        if isinstance(raw, dict):
+            return list(raw.keys())
+        if isinstance(raw, list):
+            return [c.get("name", "") if isinstance(c, dict) else str(c) for c in raw]
+        return []
+
+    for key, node in nodes.items():
+        resource_type = node.get("resource_type", "")
+        if resource_type not in ("model", "seed", "snapshot"):
+            continue
+        name = node.get("name") or node.get("alias") or key.split(".")[-1]
+        if selected_models and name not in selected_models:
+            continue
+        cols = _columns_from_node(node)
+        description = node.get("description") or ""
+        table_infos.append({"table": name, "columns": cols, "description": description})
+
+    for key, node in sources.items():
+        name = node.get("name") or key.split(".")[-1]
+        if selected_models and name not in selected_models:
+            continue
+        cols = _columns_from_node(node)
+        description = node.get("description") or ""
+        table_infos.append({"table": name, "columns": cols, "description": description})
+
+    return table_infos
+
+
+async def ask_dbt(
+    project_source: str,
+    connection_string: str,
+    question: str,
+    agent_description: str = "",
+    source_name: str | None = None,
+    # GitHub source params
+    github_token: str | None = None,
+    github_repo: str = "",
+    github_branch: str = "main",
+    manifest_path: str = "target/manifest.json",
+    # dbt Cloud params
+    dbt_cloud_token: str | None = None,
+    dbt_cloud_account_id: str = "",
+    dbt_cloud_job_id: str = "",
+    # Shared
+    selected_models: list[str] | None = None,
+    table_infos: list[dict] | None = None,
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+    sql_mode: bool = False,
+) -> dict[str, Any]:
+    """
+    Main entry point for dbt source questions.
+
+    Resolves the dbt manifest (from GitHub or dbt Cloud) if table_infos is not
+    already cached, then delegates to ask_sql for query generation and execution.
+    """
+    from app.scripts.ask_sql import ask_sql
+
+    # Resolve table_infos from manifest if not cached
+    if not table_infos:
+        if project_source == "github":
+            if not github_repo:
+                raise ValueError("githubRepo is required for GitHub dbt source.")
+            manifest = await _fetch_manifest_from_github(
+                token=github_token,
+                repo=github_repo,
+                branch=github_branch or "main",
+                manifest_path=manifest_path or "target/manifest.json",
+            )
+        elif project_source == "cloud":
+            if not dbt_cloud_token or not dbt_cloud_account_id or not dbt_cloud_job_id:
+                raise ValueError("dbtCloudToken, dbtCloudAccountId and dbtCloudJobId are required for dbt Cloud source.")
+            manifest = await _fetch_manifest_from_dbt_cloud(
+                token=dbt_cloud_token,
+                account_id=dbt_cloud_account_id,
+                job_id=dbt_cloud_job_id,
+            )
+        else:
+            raise ValueError(f"Unknown projectSource: '{project_source}'. Use 'github' or 'cloud'.")
+
+        table_infos = _extract_table_infos_from_manifest(manifest, selected_models)
+
+    if not connection_string:
+        raise ValueError("connectionString is required to query dbt models.")
+
+    return await ask_sql(
+        connection_string=connection_string,
+        question=question,
+        agent_description=agent_description,
+        source_name=source_name,
+        table_infos=table_infos,
+        llm_overrides=llm_overrides,
+        history=history,
+        channel=channel,
+        sql_mode=sql_mode,
+    )

--- a/backend/app/scripts/ask_github_file.py
+++ b/backend/app/scripts/ask_github_file.py
@@ -1,0 +1,322 @@
+"""
+Answer questions about data files hosted in a GitHub repository.
+
+Supports CSV, TSV and JSON (array of objects) files.
+Downloads the file via the GitHub API, loads into an in-memory SQLite
+table and routes to the LLM the same way as ask_csv.
+"""
+from typing import Any
+import io
+import json
+import math
+import re
+import sqlite3
+
+import httpx
+import pandas as pd
+
+
+MAX_ROWS = 100_000
+
+
+async def _download_github_file(
+    token: str | None,
+    repo: str,
+    branch: str,
+    file_path: str,
+) -> bytes:
+    """Download raw file content from a GitHub repository."""
+    headers = {"Accept": "application/vnd.github.raw+json", "X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    # Use raw content endpoint
+    url = f"https://raw.githubusercontent.com/{repo}/{branch}/{file_path}"
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.get(url, headers=headers)
+    if resp.status_code == 401:
+        raise ValueError("GitHub authentication failed. Check the token.")
+    if resp.status_code == 404:
+        raise ValueError(f"File '{file_path}' not found in {repo}@{branch}.")
+    if resp.status_code != 200:
+        raise ValueError(f"GitHub error {resp.status_code}: {resp.text[:200]}")
+    return resp.content
+
+
+def _parse_file_content(content: bytes, file_path: str) -> pd.DataFrame:
+    """Parse raw bytes into a DataFrame based on file extension."""
+    ext = file_path.rsplit(".", 1)[-1].lower() if "." in file_path else ""
+    if ext in ("csv",):
+        return pd.read_csv(io.BytesIO(content), nrows=MAX_ROWS)
+    if ext in ("tsv",):
+        return pd.read_csv(io.BytesIO(content), sep="\t", nrows=MAX_ROWS)
+    if ext in ("json", "jsonl", "ndjson"):
+        text = content.decode("utf-8")
+        # Try newline-delimited JSON first
+        lines = [l.strip() for l in text.splitlines() if l.strip()]
+        if len(lines) > 1:
+            try:
+                rows = [json.loads(l) for l in lines]
+                return pd.DataFrame(rows).head(MAX_ROWS)
+            except json.JSONDecodeError:
+                pass
+        parsed = json.loads(text)
+        if isinstance(parsed, list):
+            return pd.DataFrame(parsed).head(MAX_ROWS)
+        if isinstance(parsed, dict):
+            # Try to find a list value
+            for v in parsed.values():
+                if isinstance(v, list):
+                    return pd.DataFrame(v).head(MAX_ROWS)
+            return pd.DataFrame([parsed])
+        raise ValueError("JSON file must be an array of objects or newline-delimited JSON.")
+    raise ValueError(f"Unsupported file extension '.{ext}'. Supported: csv, tsv, json, jsonl.")
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    return v if math.isfinite(v) else None
+
+
+def _build_sample_profile(df: pd.DataFrame) -> dict:
+    profile: dict = {"sample_rows": len(df), "columns": {}}
+    if len(df) == 0:
+        return profile
+    for col in df.columns:
+        series = df[col]
+        col_profile: dict = {"type": str(series.dtype), "missing": int(series.isna().sum())}
+        if series.dtype.kind in ("i", "u", "f"):
+            numeric = series.dropna()
+            if not numeric.empty:
+                col_profile["numeric"] = {
+                    "min": _safe_float(numeric.min()),
+                    "max": _safe_float(numeric.max()),
+                    "mean": _safe_float(numeric.mean()),
+                    "median": _safe_float(numeric.median()),
+                }
+        else:
+            counts = series.dropna().astype(str).value_counts().head(3)
+            if not counts.empty:
+                col_profile["top_values"] = counts.to_dict()
+        profile["columns"][str(col)] = col_profile
+    return profile
+
+
+def _format_profile(sample_profile: dict | None, max_columns: int = 30) -> str:
+    if not sample_profile:
+        return "No sample profile available."
+    columns = sample_profile.get("columns", {})
+    lines = []
+    for i, (col, info) in enumerate(columns.items()):
+        if i >= max_columns:
+            remaining = max(len(columns) - max_columns, 0)
+            if remaining:
+                lines.append(f"... and {remaining} more columns not shown.")
+            break
+        col_type = info.get("type", "unknown")
+        missing = info.get("missing", 0)
+        line = f"- {col} (type={col_type}, missing={missing})"
+        if numeric := info.get("numeric"):
+            line += f", numeric={numeric}"
+        if top := info.get("top_values"):
+            line += f", top_values={top}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _run_sql_on_conn(conn: sqlite3.Connection, query: str) -> list[dict] | None:
+    q = query.strip().upper()
+    if not q.startswith("SELECT"):
+        raise ValueError("Only SELECT queries are allowed")
+    for forbidden in ("DELETE", "UPDATE", "INSERT", "DROP", "ALTER", "TRUNCATE", "CREATE"):
+        if forbidden in q:
+            raise ValueError("Only SELECT queries are allowed")
+    cur = conn.execute(query)
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def _parse_llm_json(raw: str) -> dict[str, Any]:
+    def _coerce(data: Any, parsed_ok: bool) -> dict[str, Any]:
+        answer = data.get("answer") if isinstance(data, dict) else None
+        follow_up = data.get("followUpQuestions") if isinstance(data, dict) else None
+        sql_query = data.get("sqlQuery") if isinstance(data, dict) else None
+        if not isinstance(answer, str):
+            answer = ""
+        if not isinstance(follow_up, list):
+            follow_up = []
+        follow_up = [q for q in follow_up if isinstance(q, str) and q.strip()]
+        if not isinstance(sql_query, str):
+            sql_query = ""
+        return {
+            "answer": answer,
+            "followUpQuestions": follow_up[:3],
+            "sqlQuery": sql_query,
+            "parsed_ok": parsed_ok,
+        }
+
+    raw_clean = raw.strip()
+    raw_clean = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw_clean, flags=re.IGNORECASE)
+    try:
+        return _coerce(json.loads(raw_clean), True)
+    except json.JSONDecodeError:
+        start = raw_clean.find("{")
+        end = raw_clean.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            try:
+                return _coerce(json.loads(raw_clean[start : end + 1]), True)
+            except json.JSONDecodeError:
+                pass
+    return _coerce({}, False)
+
+
+def _extract_followups(raw: str) -> list[str]:
+    follow_up = []
+    for line in raw.split("\n"):
+        cleaned = line.strip().replace("^[0-9]+\\.\\s*", "").replace("^-\\s*", "").strip()
+        if cleaned.endswith("?") and len(cleaned) > 15:
+            follow_up.append(cleaned)
+    return list(dict.fromkeys(follow_up))[:3]
+
+
+async def ask_github_file(
+    github_repo: str,
+    file_path: str,
+    question: str,
+    agent_description: str = "",
+    source_name: str | None = None,
+    github_token: str | None = None,
+    github_branch: str = "main",
+    columns: list[str] | None = None,
+    preview_rows: list[dict] | None = None,
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """
+    Download a data file from GitHub, load into in-memory SQLite, and answer
+    the question with the LLM — identical flow to ask_csv.
+    """
+    from app.llm.client import chat_completion
+    from app.llm.charting import build_chart_input
+    from app.llm.elaborate import elaborate_answer_with_results
+    from app.llm.followups import refine_followup_questions
+    from app.llm.logs import record_log
+    from app.scripts.sql_utils import extract_sql_from_field
+
+    content = await _download_github_file(
+        token=github_token,
+        repo=github_repo,
+        branch=github_branch or "main",
+        file_path=file_path,
+    )
+    df = _parse_file_content(content, file_path)
+    columns = list(df.columns)
+    full_row_count = len(df)
+    preview = df.head(10).to_dict(orient="records")
+    sample_profile = _build_sample_profile(df.head(1000))
+    profile_text = _format_profile(sample_profile)
+    sample_json = str(preview[:5])
+
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    schema_for_sql = (
+        f"Table 'data' with columns: {', '.join(columns)}. "
+        "Use SELECT ... FROM data. Quote column names with double quotes if they have spaces or special chars."
+    )
+
+    system = (
+        "You are an assistant that answers questions about tabular data from a GitHub repository file. "
+        "The full dataset is loaded in a table named 'data'. "
+        "For questions requiring precise filtering, counting, or aggregation, you MUST provide a SQL query in sqlQuery. "
+        "Use standard SQL: SELECT ... FROM data. Quote column names with double quotes if they have spaces or special chars. "
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), "
+        "sqlQuery (string or null). The sqlQuery will be executed on the full data for accurate results. "
+        "Any suggested follow-up questions must be answerable using only the available columns in the schema. "
+        "Do not include any extra text outside the JSON."
+    )
+    if agent_description:
+        system += f"\nAgent context: {agent_description}"
+
+    user_content = (
+        f"{schema_for_sql}\n\n"
+        f"Total rows: {full_row_count}\n"
+        f"Sample profile:\n{profile_text}\n\n"
+        f"Sample data (up to 5 rows):\n{sample_json}\n\n"
+        f"User question: {question}"
+    )
+
+    messages: list[dict] = [{"role": "system", "content": system}]
+    if history:
+        for turn in history[-5:]:
+            messages.append({"role": "user", "content": turn["question"]})
+            messages.append({"role": "assistant", "content": turn["answer"]})
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+    trace["stage"] = "pergunta_main"
+    trace["source_type"] = "github_file"
+    await record_log(
+        action="pergunta",
+        provider=usage.get("provider", ""),
+        model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0),
+        output_tokens=usage.get("output_tokens", 0),
+        source=source_name,
+        channel=channel,
+        trace=trace,
+    )
+
+    parsed = _parse_llm_json(raw_answer)
+    answer = parsed["answer"]
+    follow_up = parsed["followUpQuestions"]
+    sql_query = extract_sql_from_field(parsed.get("sqlQuery") or "")
+
+    chart_input = None
+    try:
+        if sql_query and sql_query.upper().strip().startswith("SELECT"):
+            try:
+                rows = _run_sql_on_conn(conn, sql_query)
+                if rows is not None:
+                    chart_input = build_chart_input(rows, schema_for_sql)
+                    elaborated = await elaborate_answer_with_results(
+                        question=question,
+                        query_results=rows,
+                        agent_description=agent_description,
+                        source_name=source_name,
+                        schema_text=schema_for_sql,
+                        llm_overrides=llm_overrides,
+                        channel=channel,
+                    )
+                    answer = elaborated["answer"]
+                    follow_up = elaborated["followUpQuestions"] or follow_up
+            except Exception as e:
+                answer = f"{answer}\n\n*Erro ao executar a consulta SQL: {e}*"
+    finally:
+        conn.close()
+
+    if not parsed["parsed_ok"]:
+        if not answer:
+            answer = raw_answer
+        if not follow_up:
+            follow_up = _extract_followups(raw_answer)
+
+    follow_up = await refine_followup_questions(
+        question=question,
+        candidate_questions=follow_up,
+        schema_text=schema_for_sql,
+        llm_overrides=llm_overrides,
+        channel=channel,
+    )
+
+    return {
+        "answer": answer,
+        "imageUrl": None,
+        "followUpQuestions": follow_up,
+        "chartInput": chart_input,
+    }

--- a/src/components/AddSourceModal.tsx
+++ b/src/components/AddSourceModal.tsx
@@ -10,6 +10,8 @@ import { dataClient } from "@/services/dataClient";
 import { Loader2, Upload } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { DbtSourceForm } from "@/components/DbtSourceForm";
+import { GithubFileSourceForm } from "@/components/GithubFileSourceForm";
 interface AddSourceModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -552,11 +554,13 @@ export function AddSourceModal({
           </p>
 
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="grid w-full grid-cols-4">
+            <TabsList className="grid w-full grid-cols-6">
               <TabsTrigger value="upload">{t('addSource.uploadTab')}</TabsTrigger>
               <TabsTrigger value="bigquery">{t('addSource.bigQueryTab')}</TabsTrigger>
               <TabsTrigger value="sheets">{t('addSource.sheetsTab')}</TabsTrigger>
               <TabsTrigger value="sql">{t('addSource.sqlTab')}</TabsTrigger>
+              <TabsTrigger value="dbt">dbt</TabsTrigger>
+              <TabsTrigger value="github_file">GitHub File</TabsTrigger>
             </TabsList>
 
             <TabsContent value="upload" className="space-y-4">
@@ -896,6 +900,14 @@ export function AddSourceModal({
                 </div>
 
               </div>
+            </TabsContent>
+
+            <TabsContent value="dbt" className="space-y-4">
+              <DbtSourceForm agentId={agentId} onSourceAdded={onSourceAdded} onClose={() => onOpenChange(false)} />
+            </TabsContent>
+
+            <TabsContent value="github_file" className="space-y-4">
+              <GithubFileSourceForm agentId={agentId} onSourceAdded={onSourceAdded} onClose={() => onOpenChange(false)} />
             </TabsContent>
           </Tabs>
 

--- a/src/components/DbtSourceForm.tsx
+++ b/src/components/DbtSourceForm.tsx
@@ -1,0 +1,236 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { dataClient } from "@/services/dataClient";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface DbtModel {
+  name: string;
+  columns: string[];
+  description: string;
+}
+
+interface DbtSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+}
+
+export function DbtSourceForm({ agentId, onSourceAdded, onClose }: DbtSourceFormProps) {
+  const [projectSource, setProjectSource] = useState<"github" | "cloud">("github");
+  // GitHub fields
+  const [githubToken, setGithubToken] = useState("");
+  const [githubRepo, setGithubRepo] = useState("");
+  const [githubBranch, setGithubBranch] = useState("main");
+  const [manifestPath, setManifestPath] = useState("target/manifest.json");
+  // dbt Cloud fields
+  const [dbtCloudToken, setDbtCloudToken] = useState("");
+  const [dbtCloudAccountId, setDbtCloudAccountId] = useState("");
+  const [dbtCloudJobId, setDbtCloudJobId] = useState("");
+  // Connection
+  const [connectionString, setConnectionString] = useState("");
+  // Models
+  const [availableModels, setAvailableModels] = useState<DbtModel[]>([]);
+  const [selectedModels, setSelectedModels] = useState<string[]>([]);
+  const [loadingModels, setLoadingModels] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+
+  const handleFetchModels = async () => {
+    setLoadingModels(true);
+    setAvailableModels([]);
+    setSelectedModels([]);
+    try {
+      const body =
+        projectSource === "github"
+          ? { projectSource, githubToken: githubToken || undefined, githubRepo, githubBranch, manifestPath }
+          : { projectSource, dbtCloudToken, dbtCloudAccountId, dbtCloudJobId };
+      const res = await dataClient.dbtValidateManifest(body);
+      setAvailableModels(res.models || []);
+      setSelectedModels((res.models || []).map((m) => m.name));
+      if ((res.models || []).length === 0) {
+        toast.warning("Nenhum modelo encontrado no manifest.");
+      } else {
+        toast.success(`${res.total} modelos encontrados.`);
+      }
+    } catch (e: unknown) {
+      toast.error("Erro ao buscar manifest", { description: (e as Error).message });
+    } finally {
+      setLoadingModels(false);
+    }
+  };
+
+  const handleConnect = async () => {
+    if (!connectionString.trim()) {
+      toast.error("Connection string é obrigatória para consultar os modelos dbt.");
+      return;
+    }
+    if (projectSource === "github" && !githubRepo.trim()) {
+      toast.error("githubRepo é obrigatório.");
+      return;
+    }
+    if (projectSource === "cloud" && (!dbtCloudToken || !dbtCloudAccountId || !dbtCloudJobId)) {
+      toast.error("dbtCloudToken, dbtCloudAccountId e dbtCloudJobId são obrigatórios.");
+      return;
+    }
+
+    setConnecting(true);
+    try {
+      const sourceName =
+        projectSource === "github" ? `dbt ${githubRepo}` : `dbt Cloud ${dbtCloudAccountId}`;
+
+      const tableInfos = availableModels
+        .filter((m) => selectedModels.includes(m.name))
+        .map((m) => ({ table: m.name, columns: m.columns, description: m.description }));
+
+      const metadata: Record<string, unknown> = {
+        projectSource,
+        connectionString: connectionString.trim(),
+        selectedModels: selectedModels.length > 0 ? selectedModels : null,
+        table_infos: tableInfos.length > 0 ? tableInfos : null,
+      };
+
+      if (projectSource === "github") {
+        metadata.githubToken = githubToken || null;
+        metadata.githubRepo = githubRepo.trim();
+        metadata.githubBranch = githubBranch.trim() || "main";
+        metadata.manifestPath = manifestPath.trim() || "target/manifest.json";
+      } else {
+        metadata.dbtCloudToken = dbtCloudToken.trim();
+        metadata.dbtCloudAccountId = dbtCloudAccountId.trim();
+        metadata.dbtCloudJobId = dbtCloudJobId.trim();
+      }
+
+      const source = await dataClient.createSource(sourceName, "dbt", metadata, undefined);
+      if (agentId && source?.id) {
+        const existingSources = await dataClient.listSources(agentId);
+        await Promise.all(
+          existingSources.map((s: { id: string }) => dataClient.updateSource(s.id, { is_active: false }))
+        );
+        await dataClient.updateSource(source.id, { agent_id: agentId, is_active: true });
+      }
+      toast.success("Fonte dbt criada com sucesso!");
+      onSourceAdded?.(source.id);
+      onClose();
+    } catch (e: unknown) {
+      toast.error("Erro ao criar fonte dbt", { description: (e as Error).message });
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const canFetch =
+    projectSource === "github"
+      ? githubRepo.trim().length > 0
+      : dbtCloudToken.trim().length > 0 && dbtCloudAccountId.trim().length > 0 && dbtCloudJobId.trim().length > 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Source type toggle */}
+      <div className="space-y-2">
+        <Label>Origem do manifest</Label>
+        <Select value={projectSource} onValueChange={(v) => { setProjectSource(v as "github" | "cloud"); setAvailableModels([]); setSelectedModels([]); }}>
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="github">GitHub</SelectItem>
+            <SelectItem value="cloud">dbt Cloud</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {projectSource === "github" ? (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="dbt-github-token">GitHub Token (opcional para repos públicos)</Label>
+            <Input id="dbt-github-token" type="password" placeholder="ghp_..." value={githubToken} onChange={(e) => setGithubToken(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="dbt-github-repo">Repositório <span className="text-red-500">*</span></Label>
+            <Input id="dbt-github-repo" placeholder="owner/repo" value={githubRepo} onChange={(e) => setGithubRepo(e.target.value)} />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="dbt-github-branch">Branch</Label>
+              <Input id="dbt-github-branch" placeholder="main" value={githubBranch} onChange={(e) => setGithubBranch(e.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="dbt-manifest-path">Caminho do manifest</Label>
+              <Input id="dbt-manifest-path" placeholder="target/manifest.json" value={manifestPath} onChange={(e) => setManifestPath(e.target.value)} />
+            </div>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="dbt-cloud-token">dbt Cloud Service Token <span className="text-red-500">*</span></Label>
+            <Input id="dbt-cloud-token" type="password" placeholder="dbtc_..." value={dbtCloudToken} onChange={(e) => setDbtCloudToken(e.target.value)} />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="dbt-account-id">Account ID <span className="text-red-500">*</span></Label>
+              <Input id="dbt-account-id" placeholder="12345" value={dbtCloudAccountId} onChange={(e) => setDbtCloudAccountId(e.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="dbt-job-id">Job ID <span className="text-red-500">*</span></Label>
+              <Input id="dbt-job-id" placeholder="67890" value={dbtCloudJobId} onChange={(e) => setDbtCloudJobId(e.target.value)} />
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Fetch models button */}
+      <Button type="button" variant="outline" className="w-full" onClick={handleFetchModels} disabled={!canFetch || loadingModels}>
+        {loadingModels ? <><Loader2 className="h-4 w-4 animate-spin mr-2" />Buscando modelos...</> : "Buscar modelos do manifest"}
+      </Button>
+
+      {/* Model selection */}
+      {availableModels.length > 0 && (
+        <div className="space-y-2">
+          <Label>Modelos ({selectedModels.length}/{availableModels.length} selecionados)</Label>
+          <div className="max-h-40 overflow-y-auto rounded-md border p-2 space-y-1">
+            {availableModels.map((model) => {
+              const checked = selectedModels.includes(model.name);
+              return (
+                <label key={model.name} className="flex items-start gap-2 rounded-md px-2 py-1 hover:bg-muted/50 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(e) =>
+                      setSelectedModels((cur) =>
+                        e.target.checked ? [...cur, model.name] : cur.filter((n) => n !== model.name)
+                      )
+                    }
+                    className="mt-0.5 h-4 w-4 rounded border-gray-300"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-sm font-medium">{model.name}</span>
+                    {model.description && <span className="block text-xs text-muted-foreground truncate">{model.description}</span>}
+                    {model.columns.length > 0 && (
+                      <span className="block text-xs text-muted-foreground truncate">{model.columns.join(", ")}</span>
+                    )}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Connection string */}
+      <div className="space-y-2">
+        <Label htmlFor="dbt-conn-string">Connection String do warehouse <span className="text-red-500">*</span></Label>
+        <Input id="dbt-conn-string" type="password" placeholder="postgresql://user:password@host:5432/database" value={connectionString} onChange={(e) => setConnectionString(e.target.value)} />
+        <p className="text-xs text-muted-foreground">A mesma connection string usada pelo dbt para executar as queries.</p>
+      </div>
+
+      {/* Connect button */}
+      <Button className="w-full" onClick={handleConnect} disabled={connecting || !connectionString.trim()}>
+        {connecting ? "Conectando..." : "Conectar fonte dbt"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/GithubFileSourceForm.tsx
+++ b/src/components/GithubFileSourceForm.tsx
@@ -1,0 +1,157 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { dataClient } from "@/services/dataClient";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface GithubFileSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+}
+
+export function GithubFileSourceForm({ agentId, onSourceAdded, onClose }: GithubFileSourceFormProps) {
+  const [githubToken, setGithubToken] = useState("");
+  const [githubRepo, setGithubRepo] = useState("");
+  const [githubBranch, setGithubBranch] = useState("main");
+  const [filePath, setFilePath] = useState("");
+  const [preview, setPreview] = useState<{ columns: string[]; previewRows: Record<string, unknown>[]; rowCount: number } | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+
+  const handlePreview = async () => {
+    if (!githubRepo.trim() || !filePath.trim()) {
+      toast.error("githubRepo e filePath são obrigatórios.");
+      return;
+    }
+    setLoadingPreview(true);
+    setPreview(null);
+    try {
+      const res = await dataClient.githubValidateFile({
+        githubToken: githubToken || undefined,
+        githubRepo: githubRepo.trim(),
+        githubBranch: githubBranch.trim() || "main",
+        filePath: filePath.trim(),
+      });
+      setPreview(res);
+      toast.success(`${res.rowCount} linhas detectadas, ${res.columns.length} colunas.`);
+    } catch (e: unknown) {
+      toast.error("Erro ao validar arquivo", { description: (e as Error).message });
+    } finally {
+      setLoadingPreview(false);
+    }
+  };
+
+  const handleConnect = async () => {
+    if (!githubRepo.trim() || !filePath.trim()) {
+      toast.error("githubRepo e filePath são obrigatórios.");
+      return;
+    }
+    setConnecting(true);
+    try {
+      const sourceName = `GitHub ${filePath.split("/").pop() || filePath} (${githubRepo})`;
+      const metadata: Record<string, unknown> = {
+        githubToken: githubToken || null,
+        githubRepo: githubRepo.trim(),
+        githubBranch: githubBranch.trim() || "main",
+        filePath: filePath.trim(),
+        columns: preview?.columns ?? null,
+        preview_rows: preview?.previewRows ?? null,
+        row_count: preview?.rowCount ?? null,
+      };
+
+      const source = await dataClient.createSource(sourceName, "github_file", metadata, undefined);
+      if (agentId && source?.id) {
+        const existingSources = await dataClient.listSources(agentId);
+        await Promise.all(
+          existingSources.map((s: { id: string }) => dataClient.updateSource(s.id, { is_active: false }))
+        );
+        await dataClient.updateSource(source.id, { agent_id: agentId, is_active: true });
+      }
+      toast.success("Fonte GitHub File criada com sucesso!");
+      onSourceAdded?.(source.id);
+      onClose();
+    } catch (e: unknown) {
+      toast.error("Erro ao criar fonte GitHub File", { description: (e as Error).message });
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const canPreview = githubRepo.trim().length > 0 && filePath.trim().length > 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="gh-token">GitHub Token (opcional para repos públicos)</Label>
+        <Input id="gh-token" type="password" placeholder="ghp_..." value={githubToken} onChange={(e) => setGithubToken(e.target.value)} />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="gh-repo">Repositório <span className="text-red-500">*</span></Label>
+        <Input id="gh-repo" placeholder="owner/repo" value={githubRepo} onChange={(e) => { setGithubRepo(e.target.value); setPreview(null); }} />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="gh-branch">Branch</Label>
+          <Input id="gh-branch" placeholder="main" value={githubBranch} onChange={(e) => { setGithubBranch(e.target.value); setPreview(null); }} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="gh-file-path">Caminho do arquivo <span className="text-red-500">*</span></Label>
+          <Input id="gh-file-path" placeholder="data/sales.csv" value={filePath} onChange={(e) => { setFilePath(e.target.value); setPreview(null); }} />
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">Formatos suportados: CSV, TSV, JSON (array de objetos), JSONL.</p>
+
+      {/* Preview button */}
+      <Button type="button" variant="outline" className="w-full" onClick={handlePreview} disabled={!canPreview || loadingPreview}>
+        {loadingPreview ? <><Loader2 className="h-4 w-4 animate-spin mr-2" />Carregando preview...</> : "Preview do arquivo"}
+      </Button>
+
+      {/* Preview result */}
+      {preview && (
+        <div className="rounded-md border p-3 space-y-2 bg-muted/30">
+          <p className="text-sm font-medium">
+            {preview.rowCount} linhas &bull; {preview.columns.length} colunas
+          </p>
+          <p className="text-xs text-muted-foreground break-all">{preview.columns.join(", ")}</p>
+          {preview.previewRows.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="text-xs w-full">
+                <thead>
+                  <tr>
+                    {preview.columns.slice(0, 6).map((col) => (
+                      <th key={col} className="text-left px-1 py-0.5 font-medium border-b truncate max-w-[100px]">{col}</th>
+                    ))}
+                    {preview.columns.length > 6 && <th className="text-left px-1 py-0.5 font-medium border-b">...</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.previewRows.slice(0, 3).map((row, i) => (
+                    <tr key={i}>
+                      {preview.columns.slice(0, 6).map((col) => (
+                        <td key={col} className="px-1 py-0.5 border-b text-muted-foreground truncate max-w-[100px]">
+                          {String(row[col] ?? "")}
+                        </td>
+                      ))}
+                      {preview.columns.length > 6 && <td className="px-1 py-0.5 border-b text-muted-foreground">...</td>}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Connect button */}
+      <Button className="w-full" onClick={handleConnect} disabled={connecting || !canPreview}>
+        {connecting ? "Conectando..." : "Conectar arquivo GitHub"}
+      </Button>
+    </div>
+  );
+}

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -122,7 +122,7 @@ export const apiClient = {
     await api(`/api/sources/${id}`, { method: 'DELETE' });
   },
 
-  async createSource(name: string, type: 'bigquery' | 'google_sheets' | 'sql_database', metadata: Record<string, unknown>, agentId?: string) {
+  async createSource(name: string, type: 'bigquery' | 'google_sheets' | 'sql_database' | 'dbt' | 'github_file', metadata: Record<string, unknown>, agentId?: string) {
     const data = await api<{ id: string; name: string; type: string; ownerId: string; createdAt: string; metaJSON: Record<string, unknown> }>('/api/sources', {
       method: 'POST',
       body: JSON.stringify({ name, type, metadata, agent_id: agentId ?? null }),
@@ -198,6 +198,30 @@ export const apiClient = {
   },
   async refreshSourceBigQueryMetadata(sourceId: string) {
     return api<{ metaJSON: Record<string, unknown> }>(`/api/bigquery/sources/${sourceId}/refresh-metadata`, { method: 'POST' });
+  },
+  async dbtValidateManifest(body: Record<string, unknown>) {
+    return api<{ models: Array<{ name: string; columns: string[]; description: string }>; total: number }>('/api/dbt/validate-manifest', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+  async dbtRefreshSourceMetadata(sourceId: string) {
+    return api<{ metaJSON: Record<string, unknown>; modelCount: number }>(`/api/dbt/sources/${sourceId}/refresh-metadata`, { method: 'POST' });
+  },
+  async githubValidateFile(body: Record<string, unknown>) {
+    return api<{ columns: string[]; previewRows: Record<string, unknown>[]; rowCount: number }>('/api/github/validate', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+  async githubListFiles(body: Record<string, unknown>) {
+    return api<{ files: Array<{ name: string; path: string; size: number }> }>('/api/github/list-files', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+  async githubRefreshSourceMetadata(sourceId: string) {
+    return api<{ metaJSON: Record<string, unknown> }>(`/api/github/sources/${sourceId}/refresh-metadata`, { method: 'POST' });
   },
   async getGoogleSheetsServiceEmail(): Promise<string | null> {
     const data = await api<{ email: string | null }>('/api/settings/google-sheets-service-email');


### PR DESCRIPTION
## Summary
This PR adds support for two new data source types: **dbt projects** (via GitHub or dbt Cloud) and **GitHub data files** (CSV/TSV/JSON). Both sources integrate with the existing LLM-powered question-answering pipeline, allowing users to query dbt models and GitHub-hosted data files through natural language.

## Key Changes

### Backend
- **`ask_dbt.py`**: New module to resolve dbt manifests from GitHub repositories or dbt Cloud, extract table metadata, and delegate query execution to `ask_sql`
  - Supports GitHub manifest fetching with optional token authentication
  - Supports dbt Cloud artifact retrieval via service token
  - Parses manifest nodes to extract model names, columns, and descriptions
  
- **`ask_github_file.py`**: New module to download and query data files from GitHub repositories
  - Downloads raw file content via GitHub API
  - Parses CSV, TSV, JSON, JSONL, and NDJSON formats into in-memory SQLite tables
  - Builds data profiles and sample statistics for LLM context
  - Routes to LLM with schema information and sample data for SQL generation
  
- **`dbt_router.py`**: New FastAPI router for dbt source operations
  - `/dbt/validate-manifest`: Validates credentials and lists available models
  - `/dbt/sources/{source_id}/refresh-metadata`: Re-fetches manifest and updates cached metadata
  
- **`github_router.py`**: New FastAPI router for GitHub file source operations
  - `/github/validate`: Validates file access and returns columns + preview rows
  - `/github/list-files`: Lists data files in a repository directory
  - `/github/sources/{source_id}/refresh-metadata`: Re-downloads file and updates metadata
  
- **`ask.py`**: Extended question handler to route dbt and github_file sources to their respective processors
- **`main.py`**: Registered new routers for dbt and GitHub endpoints

### Frontend
- **`DbtSourceForm.tsx`**: New form component for creating dbt sources
  - Toggle between GitHub and dbt Cloud manifest sources
  - Fetch and display available models with multi-select
  - Configure connection string for query execution
  
- **`GithubFileSourceForm.tsx`**: New form component for creating GitHub file sources
  - Input GitHub repository, branch, and file path
  - Preview file contents (columns, row count, sample data)
  - Support for public and private repositories via token
  
- **`AddSourceModal.tsx`**: Updated to include dbt and GitHub file source options
- **`apiClient.ts`**: Added methods for dbt and GitHub file validation and metadata refresh

## Implementation Details
- Both source types follow the existing pattern of downloading/fetching metadata upfront and caching it in the source record
- dbt sources delegate actual query execution to the existing `ask_sql` module, reusing SQL generation and execution logic
- GitHub file sources create in-memory SQLite tables, similar to the existing `ask_csv` flow
- LLM receives schema information, data profiles, and sample rows to generate appropriate SQL queries
- Error handling includes validation of credentials, file existence, and manifest structure
- Metadata refresh endpoints allow users to update cached information without recreating sources

https://claude.ai/code/session_0166Yjrd1RvxTFB7xUF6zK19