### PR TITLE
Fix: add API key validation in LLM client and error handling in repor…

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -130,9 +130,14 @@ async def chat_completion(
 async def _openai_chat(messages: list[dict[str, str]], max_tokens: int, cfg: dict[str, Any]) -> tuple[str, dict[str, Any], dict[str, Any]]:
     from openai import AsyncOpenAI
 
-    api_key = cfg.get("openai_api_key") or None
+    api_key = (cfg.get("openai_api_key") or "").strip() or None
     base_url = (cfg.get("openai_base_url") or "https://api.openai.com/v1").rstrip("/")
     model = cfg.get("openai_model", "gpt-4o-mini")
+    if not api_key:
+        raise ValueError(
+            "OpenAI API key is not configured. "
+            "Set it in Account > LLM / AI settings or via the OPENAI_API_KEY environment variable."
+        )
     client = AsyncOpenAI(api_key=api_key, base_url=base_url)
     resp = await client.chat.completions.create(
         model=model,

--- a/backend/app/routers/report_router.py
+++ b/backend/app/routers/report_router.py
@@ -110,55 +110,64 @@ async def generate_report(
     # Validate that an LLM API key is configured before starting the pipeline
     _validate_llm_config(llm_overrides, settings)
 
-    if source.type in ("csv", "xlsx"):
-        file_path = meta.get("file_path")
-        if not file_path:
-            raise HTTPException(400, "CSV/XLSX source missing file_path in metadata")
-        result = await generate_report_csv(
-            file_path=file_path,
-            source_name=source.name,
-            data_files_dir=settings.data_files_dir,
-            llm_overrides=llm_overrides,
-            channel="studio",
-        )
-    elif source.type == "bigquery":
-        creds = meta.get("credentialsContent") or meta.get("credentials_content")
-        if not creds:
-            raise HTTPException(400, "BigQuery source missing credentials")
-        result = await generate_report_bigquery(
-            credentials_content=creds,
-            project_id=meta.get("projectId", ""),
-            dataset_id=meta.get("datasetId", ""),
-            tables=meta.get("tables", []),
-            table_infos=meta.get("table_infos"),
-            source_name=source.name,
-            llm_overrides=llm_overrides,
-            channel="studio",
-        )
-    elif source.type == "sql_database":
-        connection_string = meta.get("connectionString") or meta.get("connection_string")
-        if not connection_string:
-            raise HTTPException(400, "SQL source missing connectionString in metadata")
-        table_infos = meta.get("table_infos")
-        if not table_infos:
-            raise HTTPException(400, "SQL source missing table_infos (schema) in metadata")
-        result = await generate_report_sql(
-            connection_string=connection_string,
-            table_infos=table_infos,
-            source_name=source.name,
-            llm_overrides=llm_overrides,
-            channel="studio",
-        )
-    elif source.type == "google_sheets":
-        result = await generate_report_google_sheets(
-            spreadsheet_id=meta.get("spreadsheetId", "") or meta.get("spreadsheet_id", ""),
-            sheet_name=meta.get("sheetName", "Sheet1") or meta.get("sheet_name", "Sheet1"),
-            source_name=source.name,
-            llm_overrides=llm_overrides,
-            channel="studio",
-        )
-    else:
-        raise HTTPException(400, f"Report not supported for source type: {source.type}")
+    try:
+        if source.type in ("csv", "xlsx"):
+            file_path = meta.get("file_path")
+            if not file_path:
+                raise HTTPException(400, "CSV/XLSX source missing file_path in metadata")
+            result = await generate_report_csv(
+                file_path=file_path,
+                source_name=source.name,
+                data_files_dir=settings.data_files_dir,
+                llm_overrides=llm_overrides,
+                channel="studio",
+            )
+        elif source.type == "bigquery":
+            creds = meta.get("credentialsContent") or meta.get("credentials_content")
+            if not creds:
+                raise HTTPException(400, "BigQuery source missing credentials")
+            result = await generate_report_bigquery(
+                credentials_content=creds,
+                project_id=meta.get("projectId", ""),
+                dataset_id=meta.get("datasetId", ""),
+                tables=meta.get("tables", []),
+                table_infos=meta.get("table_infos"),
+                source_name=source.name,
+                llm_overrides=llm_overrides,
+                channel="studio",
+            )
+        elif source.type == "sql_database":
+            connection_string = meta.get("connectionString") or meta.get("connection_string")
+            if not connection_string:
+                raise HTTPException(400, "SQL source missing connectionString in metadata")
+            table_infos = meta.get("table_infos")
+            if not table_infos:
+                raise HTTPException(400, "SQL source missing table_infos (schema) in metadata")
+            result = await generate_report_sql(
+                connection_string=connection_string,
+                table_infos=table_infos,
+                source_name=source.name,
+                llm_overrides=llm_overrides,
+                channel="studio",
+            )
+        elif source.type == "google_sheets":
+            result = await generate_report_google_sheets(
+                spreadsheet_id=meta.get("spreadsheetId", "") or meta.get("spreadsheet_id", ""),
+                sheet_name=meta.get("sheetName", "Sheet1") or meta.get("sheet_name", "Sheet1"),
+                source_name=source.name,
+                llm_overrides=llm_overrides,
+                channel="studio",
+            )
+        else:
+            raise HTTPException(400, f"Report not supported for source type: {source.type}")
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+    except Exception as exc:
+        import logging
+        logging.getLogger(__name__).exception("Report generation failed")
+        raise HTTPException(500, f"Report generation failed: {exc}")
 
     report_id = str(uuid.uuid4())
     report = Report(

--- a/backend/app/scripts/report_generator.py
+++ b/backend/app/scripts/report_generator.py
@@ -1022,7 +1022,15 @@ async def generate_report(
     profile = _profile_dataframe(df_profile)
 
     # Step 2: Observations (LLM call #1)
-    observations = await _generate_observations(profile, source_name, llm_overrides, channel)
+    try:
+        observations = await _generate_observations(profile, source_name, llm_overrides, channel)
+    except (ValueError, Exception) as exc:
+        if "api_key" in str(exc).lower() or "api key" in str(exc).lower():
+            raise ValueError(
+                "LLM API key error during report generation. "
+                "Please check your API key in Account > LLM / AI settings."
+            ) from exc
+        raise
 
     # Step 3: Plan charts (LLM call #2)
     chart_plans = await _plan_charts(profile, source_name, llm_overrides, channel)


### PR DESCRIPTION
…t pipeline

- _openai_chat now validates api_key before creating AsyncOpenAI client, raising a clear ValueError instead of an opaque openai.OpenAIError
- report_generator catches API key errors on the first LLM call and re-raises with actionable message
- report_router wraps the entire generation in try/except, converting ValueError to HTTP 400 and logging unexpected errors as 500

https://claude.ai/code/session_01RaA8WuAacBj4vrrYCwZa5a