### PR TITLE
Conditionally show LLM panel based on environment configuration

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -13,6 +13,7 @@ import { LLMPanel } from "@/components/LLMPanel";
 import { ConnectionsPanel } from "@/components/ConnectionsPanel";
 import AuditTrail from "@/components/AuditTrail";
 import { useSearchParams } from "react-router-dom";
+import { dataClient } from "@/services/dataClient";
 
 const Account = () => {
   const { t } = useLanguage();
@@ -21,11 +22,16 @@ const Account = () => {
   const [activeSection, setActiveSection] = useState("usage");
   const [showAddSourceModal, setShowAddSourceModal] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [hasEnvLlm, setHasEnvLlm] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    dataClient.getLlmStatus().then(s => setHasEnvLlm(s.has_env)).catch(() => setHasEnvLlm(false));
+  }, []);
 
   const menuItems = useMemo(() => {
     const items = [
       { id: "usage", label: t('account.tabs.usage'), icon: Activity },
-      { id: "llm", label: t('account.tabs.llm'), icon: Bot },
+      ...(hasEnvLlm ? [{ id: "llm", label: t('account.tabs.llm'), icon: Bot }] : []),
       { id: "connections", label: t('account.tabs.connections'), icon: PlugZap },
       ...(loginRequired ? [{ id: "users", label: t('account.tabs.users'), icon: Users }] : []),
       { id: "sources", label: t('account.tabs.sources'), icon: FolderOpen },
@@ -33,11 +39,15 @@ const Account = () => {
       { id: "audit", label: t('account.tabs.audit'), icon: ShieldCheck },
     ];
     return items;
-  }, [t, loginRequired]);
+  }, [t, loginRequired, hasEnvLlm]);
 
   useEffect(() => {
     if (!loginRequired && activeSection === "users") setActiveSection("usage");
   }, [loginRequired, activeSection]);
+
+  useEffect(() => {
+    if (hasEnvLlm === false && activeSection === "llm") setActiveSection("usage");
+  }, [hasEnvLlm, activeSection]);
 
   useEffect(() => {
     const requestedSection = searchParams.get("section");


### PR DESCRIPTION
## Summary
This PR adds conditional rendering of the LLM tab in the Account page based on whether an LLM is configured in the environment. The LLM panel is now only displayed when `has_env` is true from the LLM status check.

## Key Changes
- Added `dataClient.getLlmStatus()` call to check if an LLM is configured in the environment
- Introduced `hasEnvLlm` state to track LLM availability
- Conditionally include the LLM tab in the menu items only when `hasEnvLlm` is true
- Added logic to redirect from the LLM section to usage if LLM becomes unavailable
- Updated `useMemo` dependency array to include `hasEnvLlm`

## Implementation Details
- The LLM status is fetched on component mount with error handling (defaults to `false` on failure)
- The menu items are dynamically constructed using conditional spread operators
- A separate `useEffect` hook ensures users are redirected away from the LLM tab if it becomes unavailable
- The implementation gracefully handles the loading state where `hasEnvLlm` is initially `null`

https://claude.ai/code/session_01SNRWJZfQyaeAwmnX6KB3LQ