### PR TITLE
Move dbt/GitHub File CTA to modal footer and compact dbt layout

### DIFF
--- a/src/components/AddSourceModal.tsx
+++ b/src/components/AddSourceModal.tsx
@@ -8,10 +8,10 @@ import { useLanguage } from "@/contexts/LanguageContext";
 import { getConnectionStringLabel } from "@/lib/utils";
 import { dataClient } from "@/services/dataClient";
 import { Loader2, Upload } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { DbtSourceForm } from "@/components/DbtSourceForm";
-import { GithubFileSourceForm } from "@/components/GithubFileSourceForm";
+import { DbtSourceForm, DbtSourceFormHandle } from "@/components/DbtSourceForm";
+import { GithubFileSourceForm, GithubFileSourceFormHandle } from "@/components/GithubFileSourceForm";
 interface AddSourceModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -78,6 +78,13 @@ export function AddSourceModal({
   const [availableSqlTables, setAvailableSqlTables] = useState<Array<{id: string; name: string; columns?: string[]}>>([]);
   const [loadingSqlTables, setLoadingSqlTables] = useState(false);
   const [activeTab, setActiveTab] = useState("upload");
+
+  const dbtFormRef = useRef<DbtSourceFormHandle>(null);
+  const githubFileFormRef = useRef<GithubFileSourceFormHandle>(null);
+  const [dbtCanConnect, setDbtCanConnect] = useState(false);
+  const [dbtConnecting, setDbtConnecting] = useState(false);
+  const [githubCanConnect, setGithubCanConnect] = useState(false);
+  const [githubConnecting, setGithubConnecting] = useState(false);
 
   // Fetch existing BigQuery credentials and Google Sheets service email when modal opens
   useEffect(() => {
@@ -903,17 +910,17 @@ export function AddSourceModal({
             </TabsContent>
 
             <TabsContent value="dbt" className="space-y-4">
-              <DbtSourceForm agentId={agentId} onSourceAdded={onSourceAdded} onClose={() => onOpenChange(false)} />
+              <DbtSourceForm ref={dbtFormRef} agentId={agentId} onSourceAdded={onSourceAdded} onClose={() => onOpenChange(false)} onCanConnectChange={setDbtCanConnect} onConnectingChange={setDbtConnecting} />
             </TabsContent>
 
             <TabsContent value="github_file" className="space-y-4">
-              <GithubFileSourceForm agentId={agentId} onSourceAdded={onSourceAdded} onClose={() => onOpenChange(false)} />
+              <GithubFileSourceForm ref={githubFileFormRef} agentId={agentId} onSourceAdded={onSourceAdded} onClose={() => onOpenChange(false)} onCanConnectChange={setGithubCanConnect} onConnectingChange={setGithubConnecting} />
             </TabsContent>
           </Tabs>
 
         </div>
 
-        {(activeTab === "bigquery" || activeTab === "sheets" || activeTab === "sql") && (
+        {(activeTab === "bigquery" || activeTab === "sheets" || activeTab === "sql" || activeTab === "dbt" || activeTab === "github_file") && (
           <div className="flex-shrink-0 pt-6 px-1 border-t">
             {activeTab === "bigquery" && (
               <Button 
@@ -934,12 +941,30 @@ export function AddSourceModal({
               </Button>
             )}
             {activeTab === "sql" && (
-              <Button 
+              <Button
                 className="w-full"
                 onClick={handleSqlConnect}
                 disabled={!getCurrentSqlConnectionString() || !sqlDatabaseType || selectedSqlTables.length === 0 || connecting || loadingSqlTables}
               >
                 {connecting ? t('addSource.connecting') : t('addSource.sqlConnect')}
+              </Button>
+            )}
+            {activeTab === "dbt" && (
+              <Button
+                className="w-full"
+                onClick={() => dbtFormRef.current?.connect()}
+                disabled={!dbtCanConnect || dbtConnecting}
+              >
+                {dbtConnecting ? t('addSource.connecting') : t('addSource.dbtConnect')}
+              </Button>
+            )}
+            {activeTab === "github_file" && (
+              <Button
+                className="w-full"
+                onClick={() => githubFileFormRef.current?.connect()}
+                disabled={!githubCanConnect || githubConnecting}
+              >
+                {githubConnecting ? t('addSource.connecting') : t('addSource.githubConnect')}
               </Button>
             )}
           </div>

--- a/src/components/DbtSourceForm.tsx
+++ b/src/components/DbtSourceForm.tsx
@@ -5,7 +5,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useLanguage } from "@/contexts/LanguageContext";
 import { dataClient } from "@/services/dataClient";
 import { Loader2 } from "lucide-react";
-import { useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import { toast } from "sonner";
 
 interface DbtModel {
@@ -18,221 +18,217 @@ interface DbtSourceFormProps {
   agentId?: string;
   onSourceAdded?: (sourceId: string) => void;
   onClose: () => void;
+  onCanConnectChange?: (v: boolean) => void;
+  onConnectingChange?: (v: boolean) => void;
 }
 
-export function DbtSourceForm({ agentId, onSourceAdded, onClose }: DbtSourceFormProps) {
-  const { t } = useLanguage();
-  const [projectSource, setProjectSource] = useState<"github" | "cloud">("github");
-  // GitHub fields
-  const [githubToken, setGithubToken] = useState("");
-  const [githubRepo, setGithubRepo] = useState("");
-  const [githubBranch, setGithubBranch] = useState("main");
-  const [manifestPath, setManifestPath] = useState("target/manifest.json");
-  // dbt Cloud fields
-  const [dbtCloudToken, setDbtCloudToken] = useState("");
-  const [dbtCloudAccountId, setDbtCloudAccountId] = useState("");
-  const [dbtCloudJobId, setDbtCloudJobId] = useState("");
-  // Connection
-  const [connectionString, setConnectionString] = useState("");
-  // Models
-  const [availableModels, setAvailableModels] = useState<DbtModel[]>([]);
-  const [selectedModels, setSelectedModels] = useState<string[]>([]);
-  const [loadingModels, setLoadingModels] = useState(false);
-  const [connecting, setConnecting] = useState(false);
+export interface DbtSourceFormHandle {
+  connect: () => Promise<void>;
+}
 
-  const handleFetchModels = async () => {
-    setLoadingModels(true);
-    setAvailableModels([]);
-    setSelectedModels([]);
-    try {
-      const body =
-        projectSource === "github"
-          ? { projectSource, githubToken: githubToken || undefined, githubRepo, githubBranch, manifestPath }
-          : { projectSource, dbtCloudToken, dbtCloudAccountId, dbtCloudJobId };
-      const res = await dataClient.dbtValidateManifest(body);
-      setAvailableModels(res.models || []);
-      setSelectedModels((res.models || []).map((m) => m.name));
-      if ((res.models || []).length === 0) {
-        toast.warning(t('addSource.dbtNoModels'));
-      } else {
-        toast.success(t('addSource.dbtModelsFound', { count: res.total }));
+export const DbtSourceForm = forwardRef<DbtSourceFormHandle, DbtSourceFormProps>(
+  function DbtSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [projectSource, setProjectSource] = useState<"github" | "cloud">("github");
+    const [githubToken, setGithubToken] = useState("");
+    const [githubRepo, setGithubRepo] = useState("");
+    const [githubBranch, setGithubBranch] = useState("main");
+    const [manifestPath, setManifestPath] = useState("target/manifest.json");
+    const [dbtCloudToken, setDbtCloudToken] = useState("");
+    const [dbtCloudAccountId, setDbtCloudAccountId] = useState("");
+    const [dbtCloudJobId, setDbtCloudJobId] = useState("");
+    const [connectionString, setConnectionString] = useState("");
+    const [availableModels, setAvailableModels] = useState<DbtModel[]>([]);
+    const [selectedModels, setSelectedModels] = useState<string[]>([]);
+    const [loadingModels, setLoadingModels] = useState(false);
+    const [connecting, setConnecting] = useState(false);
+
+    const canFetch =
+      projectSource === "github"
+        ? githubRepo.trim().length > 0
+        : dbtCloudToken.trim().length > 0 && dbtCloudAccountId.trim().length > 0 && dbtCloudJobId.trim().length > 0;
+
+    const canConnect =
+      connectionString.trim().length > 0 &&
+      (projectSource === "github" ? githubRepo.trim().length > 0 : dbtCloudToken.trim().length > 0 && dbtCloudAccountId.trim().length > 0 && dbtCloudJobId.trim().length > 0);
+
+    const handleFetchModels = async () => {
+      setLoadingModels(true);
+      setAvailableModels([]);
+      setSelectedModels([]);
+      try {
+        const body =
+          projectSource === "github"
+            ? { projectSource, githubToken: githubToken || undefined, githubRepo, githubBranch, manifestPath }
+            : { projectSource, dbtCloudToken, dbtCloudAccountId, dbtCloudJobId };
+        const res = await dataClient.dbtValidateManifest(body);
+        setAvailableModels(res.models || []);
+        setSelectedModels((res.models || []).map((m) => m.name));
+        if ((res.models || []).length === 0) {
+          toast.warning(t('addSource.dbtNoModels'));
+        } else {
+          toast.success(t('addSource.dbtModelsFound', { count: res.total }));
+        }
+      } catch (e: unknown) {
+        toast.error(t('addSource.dbtFetchError'), { description: (e as Error).message });
+      } finally {
+        setLoadingModels(false);
       }
-    } catch (e: unknown) {
-      toast.error(t('addSource.dbtFetchError'), { description: (e as Error).message });
-    } finally {
-      setLoadingModels(false);
-    }
-  };
+    };
 
-  const handleConnect = async () => {
-    if (!connectionString.trim()) {
-      toast.error(t('addSource.sqlFillFields'));
-      return;
-    }
-    if (projectSource === "github" && !githubRepo.trim()) {
-      toast.error(t('addSource.sqlFillFields'));
-      return;
-    }
-    if (projectSource === "cloud" && (!dbtCloudToken || !dbtCloudAccountId || !dbtCloudJobId)) {
-      toast.error(t('addSource.sqlFillFields'));
-      return;
-    }
-
-    setConnecting(true);
-    try {
-      const sourceName =
-        projectSource === "github" ? `dbt ${githubRepo}` : `dbt Cloud ${dbtCloudAccountId}`;
-
-      const tableInfos = availableModels
-        .filter((m) => selectedModels.includes(m.name))
-        .map((m) => ({ table: m.name, columns: m.columns, description: m.description }));
-
-      const metadata: Record<string, unknown> = {
-        projectSource,
-        connectionString: connectionString.trim(),
-        selectedModels: selectedModels.length > 0 ? selectedModels : null,
-        table_infos: tableInfos.length > 0 ? tableInfos : null,
-      };
-
-      if (projectSource === "github") {
-        metadata.githubToken = githubToken || null;
-        metadata.githubRepo = githubRepo.trim();
-        metadata.githubBranch = githubBranch.trim() || "main";
-        metadata.manifestPath = manifestPath.trim() || "target/manifest.json";
-      } else {
-        metadata.dbtCloudToken = dbtCloudToken.trim();
-        metadata.dbtCloudAccountId = dbtCloudAccountId.trim();
-        metadata.dbtCloudJobId = dbtCloudJobId.trim();
+    const handleConnect = async () => {
+      if (!canConnect) {
+        toast.error(t('addSource.sqlFillFields'));
+        return;
       }
-
-      const source = await dataClient.createSource(sourceName, "dbt", metadata, undefined);
-      if (agentId && source?.id) {
-        const existingSources = await dataClient.listSources(agentId);
-        await Promise.all(
-          existingSources.map((s: { id: string }) => dataClient.updateSource(s.id, { is_active: false }))
-        );
-        await dataClient.updateSource(source.id, { agent_id: agentId, is_active: true });
+      setConnecting(true);
+      try {
+        const sourceName =
+          projectSource === "github" ? `dbt ${githubRepo}` : `dbt Cloud ${dbtCloudAccountId}`;
+        const tableInfos = availableModels
+          .filter((m) => selectedModels.includes(m.name))
+          .map((m) => ({ table: m.name, columns: m.columns, description: m.description }));
+        const metadata: Record<string, unknown> = {
+          projectSource,
+          connectionString: connectionString.trim(),
+          selectedModels: selectedModels.length > 0 ? selectedModels : null,
+          table_infos: tableInfos.length > 0 ? tableInfos : null,
+        };
+        if (projectSource === "github") {
+          metadata.githubToken = githubToken || null;
+          metadata.githubRepo = githubRepo.trim();
+          metadata.githubBranch = githubBranch.trim() || "main";
+          metadata.manifestPath = manifestPath.trim() || "target/manifest.json";
+        } else {
+          metadata.dbtCloudToken = dbtCloudToken.trim();
+          metadata.dbtCloudAccountId = dbtCloudAccountId.trim();
+          metadata.dbtCloudJobId = dbtCloudJobId.trim();
+        }
+        const source = await dataClient.createSource(sourceName, "dbt", metadata, undefined);
+        if (agentId && source?.id) {
+          const existingSources = await dataClient.listSources(agentId);
+          await Promise.all(
+            existingSources.map((s: { id: string }) => dataClient.updateSource(s.id, { is_active: false }))
+          );
+          await dataClient.updateSource(source.id, { agent_id: agentId, is_active: true });
+        }
+        toast.success(t('addSource.dbtConnectSuccess'));
+        onSourceAdded?.(source.id);
+        onClose();
+      } catch (e: unknown) {
+        toast.error(t('addSource.dbtConnectError'), { description: (e as Error).message });
+      } finally {
+        setConnecting(false);
       }
-      toast.success(t('addSource.dbtConnectSuccess'));
-      onSourceAdded?.(source.id);
-      onClose();
-    } catch (e: unknown) {
-      toast.error(t('addSource.dbtConnectError'), { description: (e as Error).message });
-    } finally {
-      setConnecting(false);
-    }
-  };
+    };
 
-  const canFetch =
-    projectSource === "github"
-      ? githubRepo.trim().length > 0
-      : dbtCloudToken.trim().length > 0 && dbtCloudAccountId.trim().length > 0 && dbtCloudJobId.trim().length > 0;
+    useEffect(() => { onCanConnectChange?.(canConnect); }, [canConnect]);
+    useEffect(() => { onConnectingChange?.(connecting); }, [connecting]);
+    useImperativeHandle(ref, () => ({ connect: handleConnect }));
 
-  return (
-    <div className="space-y-4">
-      {/* Source type toggle */}
-      <div className="space-y-2">
-        <Label>{t('addSource.dbtManifestOrigin')}</Label>
-        <Select value={projectSource} onValueChange={(v) => { setProjectSource(v as "github" | "cloud"); setAvailableModels([]); setSelectedModels([]); }}>
-          <SelectTrigger className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="github">{t('addSource.dbtGithub')}</SelectItem>
-            <SelectItem value="cloud">{t('addSource.dbtCloud')}</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      {projectSource === "github" ? (
-        <>
-          <div className="space-y-2">
-            <Label htmlFor="dbt-github-token">{t('addSource.dbtGithubToken')}</Label>
-            <Input id="dbt-github-token" type="password" placeholder="ghp_..." value={githubToken} onChange={(e) => setGithubToken(e.target.value)} />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="dbt-github-repo">{t('addSource.dbtGithubRepo')} <span className="text-red-500">*</span></Label>
-            <Input id="dbt-github-repo" placeholder="owner/repo" value={githubRepo} onChange={(e) => setGithubRepo(e.target.value)} />
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="dbt-github-branch">{t('addSource.dbtGithubBranch')}</Label>
-              <Input id="dbt-github-branch" placeholder="main" value={githubBranch} onChange={(e) => setGithubBranch(e.target.value)} />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="dbt-manifest-path">{t('addSource.dbtManifestPath')}</Label>
-              <Input id="dbt-manifest-path" placeholder="target/manifest.json" value={manifestPath} onChange={(e) => setManifestPath(e.target.value)} />
-            </div>
-          </div>
-        </>
-      ) : (
-        <>
-          <div className="space-y-2">
-            <Label htmlFor="dbt-cloud-token">{t('addSource.dbtCloudToken')} <span className="text-red-500">*</span></Label>
-            <Input id="dbt-cloud-token" type="password" placeholder="dbtc_..." value={dbtCloudToken} onChange={(e) => setDbtCloudToken(e.target.value)} />
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="dbt-account-id">{t('addSource.dbtCloudAccountId')} <span className="text-red-500">*</span></Label>
-              <Input id="dbt-account-id" placeholder="12345" value={dbtCloudAccountId} onChange={(e) => setDbtCloudAccountId(e.target.value)} />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="dbt-job-id">{t('addSource.dbtCloudJobId')} <span className="text-red-500">*</span></Label>
-              <Input id="dbt-job-id" placeholder="67890" value={dbtCloudJobId} onChange={(e) => setDbtCloudJobId(e.target.value)} />
-            </div>
-          </div>
-        </>
-      )}
-
-      {/* Fetch models button */}
-      <Button type="button" variant="outline" className="w-full" onClick={handleFetchModels} disabled={!canFetch || loadingModels}>
-        {loadingModels ? <><Loader2 className="h-4 w-4 animate-spin mr-2" />{t('addSource.dbtFetchingModels')}</> : t('addSource.dbtFetchModels')}
-      </Button>
-
-      {/* Model selection */}
-      {availableModels.length > 0 && (
+    return (
+      <div className="space-y-4">
+        {/* Manifest origin */}
         <div className="space-y-2">
-          <Label>{t('addSource.dbtModelsSelected', { selected: selectedModels.length, total: availableModels.length })}</Label>
-          <div className="max-h-40 overflow-y-auto rounded-md border p-2 space-y-1">
-            {availableModels.map((model) => {
-              const checked = selectedModels.includes(model.name);
-              return (
-                <label key={model.name} className="flex items-start gap-2 rounded-md px-2 py-1 hover:bg-muted/50 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={(e) =>
-                      setSelectedModels((cur) =>
-                        e.target.checked ? [...cur, model.name] : cur.filter((n) => n !== model.name)
-                      )
-                    }
-                    className="mt-0.5 h-4 w-4 rounded border-gray-300"
-                  />
-                  <span className="min-w-0">
-                    <span className="block text-sm font-medium">{model.name}</span>
-                    {model.description && <span className="block text-xs text-muted-foreground truncate">{model.description}</span>}
-                    {model.columns.length > 0 && (
-                      <span className="block text-xs text-muted-foreground truncate">{model.columns.join(", ")}</span>
-                    )}
-                  </span>
-                </label>
-              );
-            })}
-          </div>
+          <Label>{t('addSource.dbtManifestOrigin')}</Label>
+          <Select value={projectSource} onValueChange={(v) => { setProjectSource(v as "github" | "cloud"); setAvailableModels([]); setSelectedModels([]); }}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="github">{t('addSource.dbtGithub')}</SelectItem>
+              <SelectItem value="cloud">{t('addSource.dbtCloud')}</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
-      )}
 
-      {/* Connection string */}
-      <div className="space-y-2">
-        <Label htmlFor="dbt-conn-string">{t('addSource.dbtConnectionString')} <span className="text-red-500">*</span></Label>
-        <Input id="dbt-conn-string" type="password" placeholder="postgresql://user:password@host:5432/database" value={connectionString} onChange={(e) => setConnectionString(e.target.value)} />
-        <p className="text-xs text-muted-foreground">{t('addSource.dbtConnectionStringHint')}</p>
+        {projectSource === "github" ? (
+          <>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="dbt-github-token">{t('addSource.dbtGithubToken')}</Label>
+                <Input id="dbt-github-token" type="password" placeholder="ghp_..." value={githubToken} onChange={(e) => setGithubToken(e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="dbt-github-repo">{t('addSource.dbtGithubRepo')} <span className="text-red-500">*</span></Label>
+                <Input id="dbt-github-repo" placeholder="owner/repo" value={githubRepo} onChange={(e) => setGithubRepo(e.target.value)} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="dbt-github-branch">{t('addSource.dbtGithubBranch')}</Label>
+                <Input id="dbt-github-branch" placeholder="main" value={githubBranch} onChange={(e) => setGithubBranch(e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="dbt-manifest-path">{t('addSource.dbtManifestPath')}</Label>
+                <Input id="dbt-manifest-path" placeholder="target/manifest.json" value={manifestPath} onChange={(e) => setManifestPath(e.target.value)} />
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor="dbt-cloud-token">{t('addSource.dbtCloudToken')} <span className="text-red-500">*</span></Label>
+              <Input id="dbt-cloud-token" type="password" placeholder="dbtc_..." value={dbtCloudToken} onChange={(e) => setDbtCloudToken(e.target.value)} />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="dbt-account-id">{t('addSource.dbtCloudAccountId')} <span className="text-red-500">*</span></Label>
+                <Input id="dbt-account-id" placeholder="12345" value={dbtCloudAccountId} onChange={(e) => setDbtCloudAccountId(e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="dbt-job-id">{t('addSource.dbtCloudJobId')} <span className="text-red-500">*</span></Label>
+                <Input id="dbt-job-id" placeholder="67890" value={dbtCloudJobId} onChange={(e) => setDbtCloudJobId(e.target.value)} />
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Fetch models button */}
+        <Button type="button" variant="outline" className="w-full" onClick={handleFetchModels} disabled={!canFetch || loadingModels}>
+          {loadingModels ? <><Loader2 className="h-4 w-4 animate-spin mr-2" />{t('addSource.dbtFetchingModels')}</> : t('addSource.dbtFetchModels')}
+        </Button>
+
+        {/* Model selection */}
+        {availableModels.length > 0 && (
+          <div className="space-y-2">
+            <Label>{t('addSource.dbtModelsSelected', { selected: selectedModels.length, total: availableModels.length })}</Label>
+            <div className="max-h-32 overflow-y-auto rounded-md border p-2 space-y-1">
+              {availableModels.map((model) => {
+                const checked = selectedModels.includes(model.name);
+                return (
+                  <label key={model.name} className="flex items-start gap-2 rounded-md px-2 py-1 hover:bg-muted/50 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) =>
+                        setSelectedModels((cur) =>
+                          e.target.checked ? [...cur, model.name] : cur.filter((n) => n !== model.name)
+                        )
+                      }
+                      className="mt-0.5 h-4 w-4 rounded border-gray-300"
+                    />
+                    <span className="min-w-0">
+                      <span className="block text-sm font-medium">{model.name}</span>
+                      {model.description && <span className="block text-xs text-muted-foreground truncate">{model.description}</span>}
+                      {model.columns.length > 0 && (
+                        <span className="block text-xs text-muted-foreground truncate">{model.columns.join(", ")}</span>
+                      )}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Connection string */}
+        <div className="space-y-2">
+          <Label htmlFor="dbt-conn-string">{t('addSource.dbtConnectionString')} <span className="text-red-500">*</span></Label>
+          <Input id="dbt-conn-string" type="password" placeholder="postgresql://user:password@host:5432/database" value={connectionString} onChange={(e) => setConnectionString(e.target.value)} />
+          <p className="text-xs text-muted-foreground">{t('addSource.dbtConnectionStringHint')}</p>
+        </div>
       </div>
-
-      {/* Connect button */}
-      <Button className="w-full" onClick={handleConnect} disabled={connecting || !connectionString.trim()}>
-        {connecting ? t('addSource.connecting') : t('addSource.dbtConnect')}
-      </Button>
-    </div>
-  );
-}
+    );
+  }
+);

--- a/src/components/GithubFileSourceForm.tsx
+++ b/src/components/GithubFileSourceForm.tsx
@@ -1,159 +1,161 @@
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { dataClient } from "@/services/dataClient";
 import { Loader2 } from "lucide-react";
-import { useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import { toast } from "sonner";
 
 interface GithubFileSourceFormProps {
   agentId?: string;
   onSourceAdded?: (sourceId: string) => void;
   onClose: () => void;
+  onCanConnectChange?: (v: boolean) => void;
+  onConnectingChange?: (v: boolean) => void;
 }
 
-export function GithubFileSourceForm({ agentId, onSourceAdded, onClose }: GithubFileSourceFormProps) {
-  const { t } = useLanguage();
-  const [githubToken, setGithubToken] = useState("");
-  const [githubRepo, setGithubRepo] = useState("");
-  const [githubBranch, setGithubBranch] = useState("main");
-  const [filePath, setFilePath] = useState("");
-  const [preview, setPreview] = useState<{ columns: string[]; previewRows: Record<string, unknown>[]; rowCount: number } | null>(null);
-  const [loadingPreview, setLoadingPreview] = useState(false);
-  const [connecting, setConnecting] = useState(false);
+export interface GithubFileSourceFormHandle {
+  connect: () => Promise<void>;
+}
 
-  const handlePreview = async () => {
-    if (!githubRepo.trim() || !filePath.trim()) {
-      toast.error(t('addSource.sqlFillFields'));
-      return;
-    }
-    setLoadingPreview(true);
-    setPreview(null);
-    try {
-      const res = await dataClient.githubValidateFile({
-        githubToken: githubToken || undefined,
-        githubRepo: githubRepo.trim(),
-        githubBranch: githubBranch.trim() || "main",
-        filePath: filePath.trim(),
-      });
-      setPreview(res);
-      toast.success(t('addSource.githubRowsColumns', { rows: res.rowCount, cols: res.columns.length }));
-    } catch (e: unknown) {
-      toast.error(t('addSource.githubValidateError'), { description: (e as Error).message });
-    } finally {
-      setLoadingPreview(false);
-    }
-  };
+export const GithubFileSourceForm = forwardRef<GithubFileSourceFormHandle, GithubFileSourceFormProps>(
+  function GithubFileSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [githubToken, setGithubToken] = useState("");
+    const [githubRepo, setGithubRepo] = useState("");
+    const [githubBranch, setGithubBranch] = useState("main");
+    const [filePath, setFilePath] = useState("");
+    const [preview, setPreview] = useState<{ columns: string[]; previewRows: Record<string, unknown>[]; rowCount: number } | null>(null);
+    const [loadingPreview, setLoadingPreview] = useState(false);
+    const [connecting, setConnecting] = useState(false);
 
-  const handleConnect = async () => {
-    if (!githubRepo.trim() || !filePath.trim()) {
-      toast.error(t('addSource.sqlFillFields'));
-      return;
-    }
-    setConnecting(true);
-    try {
-      const sourceName = `GitHub ${filePath.split("/").pop() || filePath} (${githubRepo})`;
-      const metadata: Record<string, unknown> = {
-        githubToken: githubToken || null,
-        githubRepo: githubRepo.trim(),
-        githubBranch: githubBranch.trim() || "main",
-        filePath: filePath.trim(),
-        columns: preview?.columns ?? null,
-        preview_rows: preview?.previewRows ?? null,
-        row_count: preview?.rowCount ?? null,
-      };
+    const canConnect = githubRepo.trim().length > 0 && filePath.trim().length > 0;
 
-      const source = await dataClient.createSource(sourceName, "github_file", metadata, undefined);
-      if (agentId && source?.id) {
-        const existingSources = await dataClient.listSources(agentId);
-        await Promise.all(
-          existingSources.map((s: { id: string }) => dataClient.updateSource(s.id, { is_active: false }))
-        );
-        await dataClient.updateSource(source.id, { agent_id: agentId, is_active: true });
+    const handlePreview = async () => {
+      setLoadingPreview(true);
+      setPreview(null);
+      try {
+        const res = await dataClient.githubValidateFile({
+          githubToken: githubToken || undefined,
+          githubRepo: githubRepo.trim(),
+          githubBranch: githubBranch.trim() || "main",
+          filePath: filePath.trim(),
+        });
+        setPreview(res);
+        toast.success(t('addSource.githubRowsColumns', { rows: res.rowCount, cols: res.columns.length }));
+      } catch (e: unknown) {
+        toast.error(t('addSource.githubValidateError'), { description: (e as Error).message });
+      } finally {
+        setLoadingPreview(false);
       }
-      toast.success(t('addSource.githubConnectSuccess'));
-      onSourceAdded?.(source.id);
-      onClose();
-    } catch (e: unknown) {
-      toast.error(t('addSource.githubConnectError'), { description: (e as Error).message });
-    } finally {
-      setConnecting(false);
-    }
-  };
+    };
 
-  const canPreview = githubRepo.trim().length > 0 && filePath.trim().length > 0;
+    const handleConnect = async () => {
+      if (!canConnect) {
+        toast.error(t('addSource.sqlFillFields'));
+        return;
+      }
+      setConnecting(true);
+      try {
+        const sourceName = `GitHub ${filePath.split("/").pop() || filePath} (${githubRepo})`;
+        const metadata: Record<string, unknown> = {
+          githubToken: githubToken || null,
+          githubRepo: githubRepo.trim(),
+          githubBranch: githubBranch.trim() || "main",
+          filePath: filePath.trim(),
+          columns: preview?.columns ?? null,
+          preview_rows: preview?.previewRows ?? null,
+          row_count: preview?.rowCount ?? null,
+        };
+        const source = await dataClient.createSource(sourceName, "github_file", metadata, undefined);
+        if (agentId && source?.id) {
+          const existingSources = await dataClient.listSources(agentId);
+          await Promise.all(
+            existingSources.map((s: { id: string }) => dataClient.updateSource(s.id, { is_active: false }))
+          );
+          await dataClient.updateSource(source.id, { agent_id: agentId, is_active: true });
+        }
+        toast.success(t('addSource.githubConnectSuccess'));
+        onSourceAdded?.(source.id);
+        onClose();
+      } catch (e: unknown) {
+        toast.error(t('addSource.githubConnectError'), { description: (e as Error).message });
+      } finally {
+        setConnecting(false);
+      }
+    };
 
-  return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor="gh-token">{t('addSource.githubToken')}</Label>
-        <Input id="gh-token" type="password" placeholder="ghp_..." value={githubToken} onChange={(e) => setGithubToken(e.target.value)} />
-      </div>
+    useEffect(() => { onCanConnectChange?.(canConnect); }, [canConnect]);
+    useEffect(() => { onConnectingChange?.(connecting); }, [connecting]);
+    useImperativeHandle(ref, () => ({ connect: handleConnect }));
 
-      <div className="space-y-2">
-        <Label htmlFor="gh-repo">{t('addSource.githubRepo')} <span className="text-red-500">*</span></Label>
-        <Input id="gh-repo" placeholder="owner/repo" value={githubRepo} onChange={(e) => { setGithubRepo(e.target.value); setPreview(null); }} />
-      </div>
-
-      <div className="grid grid-cols-2 gap-4">
+    return (
+      <div className="space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="gh-branch">{t('addSource.githubBranch')}</Label>
-          <Input id="gh-branch" placeholder="main" value={githubBranch} onChange={(e) => { setGithubBranch(e.target.value); setPreview(null); }} />
+          <Label htmlFor="gh-token">{t('addSource.githubToken')}</Label>
+          <Input id="gh-token" type="password" placeholder="ghp_..." value={githubToken} onChange={(e) => setGithubToken(e.target.value)} />
         </div>
+
         <div className="space-y-2">
-          <Label htmlFor="gh-file-path">{t('addSource.githubFilePath')} <span className="text-red-500">*</span></Label>
-          <Input id="gh-file-path" placeholder="data/sales.csv" value={filePath} onChange={(e) => { setFilePath(e.target.value); setPreview(null); }} />
+          <Label htmlFor="gh-repo">{t('addSource.githubRepo')} <span className="text-red-500">*</span></Label>
+          <Input id="gh-repo" placeholder="owner/repo" value={githubRepo} onChange={(e) => { setGithubRepo(e.target.value); setPreview(null); }} />
         </div>
-      </div>
 
-      <p className="text-xs text-muted-foreground">{t('addSource.githubSupportedFormats')}</p>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="gh-branch">{t('addSource.githubBranch')}</Label>
+            <Input id="gh-branch" placeholder="main" value={githubBranch} onChange={(e) => { setGithubBranch(e.target.value); setPreview(null); }} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="gh-file-path">{t('addSource.githubFilePath')} <span className="text-red-500">*</span></Label>
+            <Input id="gh-file-path" placeholder="data/sales.csv" value={filePath} onChange={(e) => { setFilePath(e.target.value); setPreview(null); }} />
+          </div>
+        </div>
 
-      {/* Preview button */}
-      <Button type="button" variant="outline" className="w-full" onClick={handlePreview} disabled={!canPreview || loadingPreview}>
-        {loadingPreview ? <><Loader2 className="h-4 w-4 animate-spin mr-2" />{t('addSource.githubPreviewing')}</> : t('addSource.githubPreview')}
-      </Button>
+        <p className="text-xs text-muted-foreground">{t('addSource.githubSupportedFormats')}</p>
 
-      {/* Preview result */}
-      {preview && (
-        <div className="rounded-md border p-3 space-y-2 bg-muted/30">
-          <p className="text-sm font-medium">
-            {t('addSource.githubRowsColumns', { rows: preview.rowCount, cols: preview.columns.length })}
-          </p>
-          <p className="text-xs text-muted-foreground break-all">{preview.columns.join(", ")}</p>
-          {preview.previewRows.length > 0 && (
-            <div className="overflow-x-auto">
-              <table className="text-xs w-full">
-                <thead>
-                  <tr>
-                    {preview.columns.slice(0, 6).map((col) => (
-                      <th key={col} className="text-left px-1 py-0.5 font-medium border-b truncate max-w-[100px]">{col}</th>
-                    ))}
-                    {preview.columns.length > 6 && <th className="text-left px-1 py-0.5 font-medium border-b">...</th>}
-                  </tr>
-                </thead>
-                <tbody>
-                  {preview.previewRows.slice(0, 3).map((row, i) => (
-                    <tr key={i}>
+        {/* Preview button */}
+        <Button type="button" variant="outline" className="w-full" onClick={handlePreview} disabled={!canConnect || loadingPreview}>
+          {loadingPreview ? <><Loader2 className="h-4 w-4 animate-spin mr-2" />{t('addSource.githubPreviewing')}</> : t('addSource.githubPreview')}
+        </Button>
+
+        {/* Preview result */}
+        {preview && (
+          <div className="rounded-md border p-3 space-y-2 bg-muted/30">
+            <p className="text-sm font-medium">
+              {t('addSource.githubRowsColumns', { rows: preview.rowCount, cols: preview.columns.length })}
+            </p>
+            <p className="text-xs text-muted-foreground break-all">{preview.columns.join(", ")}</p>
+            {preview.previewRows.length > 0 && (
+              <div className="overflow-x-auto">
+                <table className="text-xs w-full">
+                  <thead>
+                    <tr>
                       {preview.columns.slice(0, 6).map((col) => (
-                        <td key={col} className="px-1 py-0.5 border-b text-muted-foreground truncate max-w-[100px]">
-                          {String(row[col] ?? "")}
-                        </td>
+                        <th key={col} className="text-left px-1 py-0.5 font-medium border-b truncate max-w-[100px]">{col}</th>
                       ))}
-                      {preview.columns.length > 6 && <td className="px-1 py-0.5 border-b text-muted-foreground">...</td>}
+                      {preview.columns.length > 6 && <th className="text-left px-1 py-0.5 font-medium border-b">...</th>}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Connect button */}
-      <Button className="w-full" onClick={handleConnect} disabled={connecting || !canPreview}>
-        {connecting ? t('addSource.connecting') : t('addSource.githubConnect')}
-      </Button>
-    </div>
-  );
-}
+                  </thead>
+                  <tbody>
+                    {preview.previewRows.slice(0, 3).map((row, i) => (
+                      <tr key={i}>
+                        {preview.columns.slice(0, 6).map((col) => (
+                          <td key={col} className="px-1 py-0.5 border-b text-muted-foreground truncate max-w-[100px]">
+                            {String(row[col] ?? "")}
+                          </td>
+                        ))}
+                        {preview.columns.length > 6 && <td className="px-1 py-0.5 border-b text-muted-foreground">...</td>}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+);


### PR DESCRIPTION
- DbtSourceForm: use forwardRef + useImperativeHandle to expose connect(), notify parent of canConnect/connecting via callbacks; compact layout puts Token+Repo in same grid row (2 cols) so form fits without modal scrolling; remove CTA button from form body
- GithubFileSourceForm: same ref/callback pattern; remove CTA button from form body
- AddSourceModal: add refs and reactive state (dbtCanConnect, dbtConnecting, githubCanConnect, githubConnecting) for both forms; extend bottom CTA section to include dbt and github_file tabs following the same pattern as bigquery/sheets/sql

https://claude.ai/code/session_0166Yjrd1RvxTFB7xUF6zK19