### PR TITLE
refactor: unify AddSourceModal with data-driven tab configuration

### DIFF
--- a/src/components/AddSourceModal.tsx
+++ b/src/components/AddSourceModal.tsx
@@ -2,13 +2,31 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useLanguage } from "@/contexts/LanguageContext";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { BigQuerySourceForm, BigQuerySourceFormHandle } from "@/components/BigQuerySourceForm";
 import { DbtSourceForm, DbtSourceFormHandle } from "@/components/DbtSourceForm";
 import { GithubFileSourceForm, GithubFileSourceFormHandle } from "@/components/GithubFileSourceForm";
 import { GoogleSheetsSourceForm, GoogleSheetsSourceFormHandle } from "@/components/GoogleSheetsSourceForm";
 import { SqlSourceForm, SqlSourceFormHandle } from "@/components/SqlSourceForm";
 import { UploadSourceForm } from "@/components/UploadSourceForm";
+
+type ConnectableHandle = { connect(): Promise<void> };
+
+interface SourceTab {
+  key: string;
+  labelKey: string;
+  connectLabelKey: string;
+  hasConnect: boolean;
+}
+
+const SOURCE_TABS: SourceTab[] = [
+  { key: "upload",      labelKey: "addSource.uploadTab",    connectLabelKey: "",                        hasConnect: false },
+  { key: "bigquery",    labelKey: "addSource.bigQueryTab",  connectLabelKey: "addSource.connectBigQuery", hasConnect: true },
+  { key: "sheets",      labelKey: "addSource.sheetsTab",    connectLabelKey: "addSource.connectSheets",   hasConnect: true },
+  { key: "sql",         labelKey: "addSource.sqlTab",       connectLabelKey: "addSource.sqlConnect",      hasConnect: true },
+  { key: "dbt",         labelKey: "dbt",                    connectLabelKey: "addSource.dbtConnect",      hasConnect: true },
+  { key: "github_file", labelKey: "GitHub File",            connectLabelKey: "addSource.githubConnect",   hasConnect: true },
+];
 
 interface AddSourceModalProps {
   open: boolean;
@@ -21,31 +39,41 @@ export function AddSourceModal({
   open,
   onOpenChange,
   onSourceAdded,
-  agentId
+  agentId,
 }: AddSourceModalProps) {
   const { t } = useLanguage();
   const [activeTab, setActiveTab] = useState("upload");
 
-  // Refs for imperative connect
-  const bigQueryRef = useRef<BigQuerySourceFormHandle>(null);
-  const sheetsRef = useRef<GoogleSheetsSourceFormHandle>(null);
-  const sqlRef = useRef<SqlSourceFormHandle>(null);
-  const dbtFormRef = useRef<DbtSourceFormHandle>(null);
-  const githubFileFormRef = useRef<GithubFileSourceFormHandle>(null);
+  // Single ref map for all connectable forms
+  const refs = useRef<Record<string, ConnectableHandle | null>>({});
 
-  // Per-tab connection state
-  const [bigQueryCanConnect, setBigQueryCanConnect] = useState(false);
-  const [bigQueryConnecting, setBigQueryConnecting] = useState(false);
-  const [sheetsCanConnect, setSheetsCanConnect] = useState(false);
-  const [sheetsConnecting, setSheetsConnecting] = useState(false);
-  const [sqlCanConnect, setSqlCanConnect] = useState(false);
-  const [sqlConnecting, setSqlConnecting] = useState(false);
-  const [dbtCanConnect, setDbtCanConnect] = useState(false);
-  const [dbtConnecting, setDbtConnecting] = useState(false);
-  const [githubCanConnect, setGithubCanConnect] = useState(false);
-  const [githubConnecting, setGithubConnecting] = useState(false);
+  // Per-tab connection state tracked in a single object
+  const [canConnect, setCanConnect] = useState<Record<string, boolean>>({});
+  const [connecting, setConnecting] = useState<Record<string, boolean>>({});
+
+  const setRef = useCallback(
+    (key: string) => (handle: ConnectableHandle | null) => {
+      refs.current[key] = handle;
+    },
+    [],
+  );
+
+  const setCanConnectFor = useCallback(
+    (key: string) => (v: boolean) =>
+      setCanConnect((prev) => ({ ...prev, [key]: v })),
+    [],
+  );
+
+  const setConnectingFor = useCallback(
+    (key: string) => (v: boolean) =>
+      setConnecting((prev) => ({ ...prev, [key]: v })),
+    [],
+  );
 
   const onClose = () => onOpenChange(false);
+
+  const activeConfig = SOURCE_TABS.find((tab) => tab.key === activeTab);
+  const showFooter = activeConfig?.hasConnect;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -61,12 +89,11 @@ export function AddSourceModal({
 
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
             <TabsList className="grid w-full grid-cols-6">
-              <TabsTrigger value="upload">{t('addSource.uploadTab')}</TabsTrigger>
-              <TabsTrigger value="bigquery">{t('addSource.bigQueryTab')}</TabsTrigger>
-              <TabsTrigger value="sheets">{t('addSource.sheetsTab')}</TabsTrigger>
-              <TabsTrigger value="sql">{t('addSource.sqlTab')}</TabsTrigger>
-              <TabsTrigger value="dbt">dbt</TabsTrigger>
-              <TabsTrigger value="github_file">GitHub File</TabsTrigger>
+              {SOURCE_TABS.map((tab) => (
+                <TabsTrigger key={tab.key} value={tab.key}>
+                  {tab.labelKey.startsWith("addSource.") ? t(tab.labelKey) : tab.labelKey}
+                </TabsTrigger>
+              ))}
             </TabsList>
 
             <TabsContent value="upload" className="space-y-4">
@@ -74,54 +101,38 @@ export function AddSourceModal({
             </TabsContent>
 
             <TabsContent value="bigquery" className="space-y-4">
-              <BigQuerySourceForm ref={bigQueryRef} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setBigQueryCanConnect} onConnectingChange={setBigQueryConnecting} />
+              <BigQuerySourceForm ref={setRef("bigquery")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("bigquery")} onConnectingChange={setConnectingFor("bigquery")} />
             </TabsContent>
 
             <TabsContent value="sheets" className="space-y-4">
-              <GoogleSheetsSourceForm ref={sheetsRef} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setSheetsCanConnect} onConnectingChange={setSheetsConnecting} />
+              <GoogleSheetsSourceForm ref={setRef("sheets")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("sheets")} onConnectingChange={setConnectingFor("sheets")} />
             </TabsContent>
 
             <TabsContent value="sql" className="space-y-4">
-              <SqlSourceForm ref={sqlRef} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setSqlCanConnect} onConnectingChange={setSqlConnecting} />
+              <SqlSourceForm ref={setRef("sql")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("sql")} onConnectingChange={setConnectingFor("sql")} />
             </TabsContent>
 
             <TabsContent value="dbt" className="space-y-4">
-              <DbtSourceForm ref={dbtFormRef} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setDbtCanConnect} onConnectingChange={setDbtConnecting} />
+              <DbtSourceForm ref={setRef("dbt")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("dbt")} onConnectingChange={setConnectingFor("dbt")} />
             </TabsContent>
 
             <TabsContent value="github_file" className="space-y-4">
-              <GithubFileSourceForm ref={githubFileFormRef} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setGithubCanConnect} onConnectingChange={setGithubConnecting} />
+              <GithubFileSourceForm ref={setRef("github_file")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("github_file")} onConnectingChange={setConnectingFor("github_file")} />
             </TabsContent>
           </Tabs>
         </div>
 
-        {activeTab !== "upload" && (
+        {showFooter && activeConfig && (
           <div className="flex-shrink-0 pt-6 px-1 border-t">
-            {activeTab === "bigquery" && (
-              <Button className="w-full" onClick={() => bigQueryRef.current?.connect()} disabled={!bigQueryCanConnect || bigQueryConnecting}>
-                {bigQueryConnecting ? t('addSource.connecting') : t('addSource.connectBigQuery')}
-              </Button>
-            )}
-            {activeTab === "sheets" && (
-              <Button className="w-full" onClick={() => sheetsRef.current?.connect()} disabled={!sheetsCanConnect || sheetsConnecting}>
-                {sheetsConnecting ? t('addSource.connecting') : t('addSource.connectSheets')}
-              </Button>
-            )}
-            {activeTab === "sql" && (
-              <Button className="w-full" onClick={() => sqlRef.current?.connect()} disabled={!sqlCanConnect || sqlConnecting}>
-                {sqlConnecting ? t('addSource.connecting') : t('addSource.sqlConnect')}
-              </Button>
-            )}
-            {activeTab === "dbt" && (
-              <Button className="w-full" onClick={() => dbtFormRef.current?.connect()} disabled={!dbtCanConnect || dbtConnecting}>
-                {dbtConnecting ? t('addSource.connecting') : t('addSource.dbtConnect')}
-              </Button>
-            )}
-            {activeTab === "github_file" && (
-              <Button className="w-full" onClick={() => githubFileFormRef.current?.connect()} disabled={!githubCanConnect || githubConnecting}>
-                {githubConnecting ? t('addSource.connecting') : t('addSource.githubConnect')}
-              </Button>
-            )}
+            <Button
+              className="w-full"
+              onClick={() => refs.current[activeTab]?.connect()}
+              disabled={!canConnect[activeTab] || connecting[activeTab]}
+            >
+              {connecting[activeTab]
+                ? t('addSource.connecting')
+                : t(activeConfig.connectLabelKey)}
+            </Button>
           </div>
         )}
       </DialogContent>


### PR DESCRIPTION
Replace 5 separate ref declarations, 10 individual useState calls, and 5 repeated connect-button blocks with a single SOURCE_TABS config array and generic state maps (canConnect, connecting).

The footer button now renders from the active tab's config instead of per-tab conditionals. Adding a new datasource tab only requires adding one entry to SOURCE_TABS and the corresponding TabsContent.

https://claude.ai/code/session_01RHvuBBwngcHxXEmc4qDhPi