### PR TITLE
Always show LLM tab, conditionally show env config

### DIFF
--- a/src/components/LLMPanel.tsx
+++ b/src/components/LLMPanel.tsx
@@ -67,10 +67,11 @@ interface EffectiveLlmSettings {
 }
 
 interface LLMPanelProps {
+  hasEnvLlm?: boolean;
   onConfigAdded?: () => void;
 }
 
-export function LLMPanel({ onConfigAdded }: LLMPanelProps = {}) {
+export function LLMPanel({ hasEnvLlm, onConfigAdded }: LLMPanelProps = {}) {
   const { t } = useLanguage();
   const [configs, setConfigs] = useState<LlmConfig[]>([]);
   const [effectiveSettings, setEffectiveSettings] = useState<EffectiveLlmSettings | null>(null);
@@ -447,7 +448,7 @@ export function LLMPanel({ onConfigAdded }: LLMPanelProps = {}) {
           </div>
         ) : (
           <div className="space-y-3">
-            {effectiveSettings && (
+            {hasEnvLlm && effectiveSettings && (
               <div className="p-3 rounded-lg border transition-all bg-muted/30 border-muted hover:bg-muted/50">
                 <div className="flex items-center gap-2">
                   <Bot className="h-4 w-4 flex-shrink-0 text-muted-foreground" />

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -31,7 +31,7 @@ const Account = () => {
   const menuItems = useMemo(() => {
     const items = [
       { id: "usage", label: t('account.tabs.usage'), icon: Activity },
-      ...(hasEnvLlm ? [{ id: "llm", label: t('account.tabs.llm'), icon: Bot }] : []),
+      { id: "llm", label: t('account.tabs.llm'), icon: Bot },
       { id: "connections", label: t('account.tabs.connections'), icon: PlugZap },
       ...(loginRequired ? [{ id: "users", label: t('account.tabs.users'), icon: Users }] : []),
       { id: "sources", label: t('account.tabs.sources'), icon: FolderOpen },
@@ -39,15 +39,11 @@ const Account = () => {
       { id: "audit", label: t('account.tabs.audit'), icon: ShieldCheck },
     ];
     return items;
-  }, [t, loginRequired, hasEnvLlm]);
+  }, [t, loginRequired]);
 
   useEffect(() => {
     if (!loginRequired && activeSection === "users") setActiveSection("usage");
   }, [loginRequired, activeSection]);
-
-  useEffect(() => {
-    if (hasEnvLlm === false && activeSection === "llm") setActiveSection("usage");
-  }, [hasEnvLlm, activeSection]);
 
   useEffect(() => {
     const requestedSection = searchParams.get("section");
@@ -103,7 +99,7 @@ const Account = () => {
           <div className="min-h-0 flex flex-col overflow-hidden">
             <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden" style={{ minHeight: 0 }}>
               {activeSection === "usage" && <UsageMonitoring />}
-              {activeSection === "llm" && <LLMPanel />}
+              {activeSection === "llm" && <LLMPanel hasEnvLlm={hasEnvLlm ?? false} />}
               {activeSection === "connections" && <ConnectionsPanel />}
               {activeSection === "users" && <UsersManagement />}
               {activeSection === "sources" && (


### PR DESCRIPTION
## Changes

- **LLMPanel.tsx**: Added `hasEnvLlm` prop to control visibility of environment LLM configuration box
- **Account.tsx**: 
  - Always render LLM tab in menu (removed conditional rendering)
  - Pass `hasEnvLlm` prop to LLMPanel to conditionally display environment config
  - Removed unnecessary useEffect that redirected away from LLM tab when env config unavailable
  - Simplified menu items dependency array

## Impact
Users can now always access the LLM tab, but the environment configuration section is only shown when env LLM is configured.