### PR TITLE
fix: correct Alembic migration chain for Google/Anthropic providers

### DIFF
--- a/backend/alembic/versions/20260318120000_add_google_anthropic_to_llm_tables.py
+++ b/backend/alembic/versions/20260318120000_add_google_anthropic_to_llm_tables.py
@@ -8,7 +8,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "20260318120000"
-down_revision: Union[str, None] = "20260316120000"
+down_revision: Union[str, None] = "65a4c2b4de29"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- Fix Alembic "multiple heads" error by correcting `down_revision` in the Google/Anthropic migration
- Was pointing to `20260316120000` (same parent as Slack migration), now correctly chains after `65a4c2b4de29` (Slack)

## Test plan
- [ ] `cd backend && uv run alembic upgrade head` runs without errors
- [ ] `llm_settings` and `llm_configs` tables have the new `google_api_key`, `google_model`, `anthropic_api_key`, `anthropic_model` columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)