### PR TITLE
fix: correct migration down_revision to chain after Slack migration

### DIFF
--- a/backend/alembic/versions/20260318120000_add_google_anthropic_to_llm_tables.py
+++ b/backend/alembic/versions/20260318120000_add_google_anthropic_to_llm_tables.py
@@ -8,7 +8,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "20260318120000"
-down_revision: Union[str, None] = "20260316120000"
+down_revision: Union[str, None] = "65a4c2b4de29"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
The Google/Anthropic migration had the same down_revision as the Slack migration, creating a branch conflict in Alembic. Now correctly chains after 65a4c2b4de29 (Slack integration).