### PR TITLE
fix: add Google/Anthropic fields to frontend API client types

### DIFF
--- a/src/components/LLMPanel.tsx
+++ b/src/components/LLMPanel.tsx
@@ -568,7 +568,7 @@ export function LLMPanel({ hasEnvLlm, onConfigAdded }: LLMPanelProps = {}) {
                             {PROVIDER_LABELS[cfg.llm_provider] || cfg.llm_provider}
                           </Badge>
                           <span className="text-xs text-muted-foreground">
-                            {cfg.model || cfg.openai_model || cfg.ollama_model || cfg.litellm_model || "—"}
+                            {cfg.model || cfg.openai_model || cfg.ollama_model || cfg.litellm_model || cfg.google_model || cfg.anthropic_model || "—"}
                           </span>
                           {(cfg.openai_audio_model || cfg.litellm_audio_model) && (
                             <>

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -468,6 +468,10 @@ export const apiClient = {
       litellm_model?: string;
       litellm_audio_model?: string;
       litellm_api_key?: string;
+      google_api_key?: string;
+      google_model?: string;
+      anthropic_api_key?: string;
+      anthropic_model?: string;
     }>('/api/settings/llm');
   },
 
@@ -483,6 +487,10 @@ export const apiClient = {
     litellm_model?: string;
     litellm_audio_model?: string;
     litellm_api_key?: string;
+    google_api_key?: string;
+    google_model?: string;
+    anthropic_api_key?: string;
+    anthropic_model?: string;
   }) {
     return api<{
       llm_provider: string;
@@ -496,6 +504,10 @@ export const apiClient = {
       litellm_model?: string;
       litellm_audio_model?: string;
       litellm_api_key?: string;
+      google_api_key?: string;
+      google_model?: string;
+      anthropic_api_key?: string;
+      anthropic_model?: string;
     }>('/api/settings/llm', { method: 'PATCH', body: JSON.stringify(body) });
   },
 
@@ -524,6 +536,10 @@ export const apiClient = {
       litellm_model?: string;
       litellm_audio_model?: string;
       litellm_api_key?: string;
+      google_api_key?: string;
+      google_model?: string;
+      anthropic_api_key?: string;
+      anthropic_model?: string;
       created_at?: string;
     }>>('/api/settings/llm-configs');
   },
@@ -541,6 +557,10 @@ export const apiClient = {
     litellm_model?: string;
     litellm_audio_model?: string;
     litellm_api_key?: string;
+    google_api_key?: string;
+    google_model?: string;
+    anthropic_api_key?: string;
+    anthropic_model?: string;
   }) {
     return api('/api/settings/llm-configs', { method: 'POST', body: JSON.stringify(body) });
   },


### PR DESCRIPTION
## Summary
- Added `google_api_key`, `google_model`, `anthropic_api_key`, `anthropic_model` fields to all LLM-related TypeScript type definitions in `apiClient.ts` (getLlmSettings, updateLlmSettings, listLlmConfigs, createLlmConfig)
- Fixed model name display in LLMPanel config cards to show Google and Anthropic model names

## Context
PR #51 added Google Gemini and Anthropic Claude as backend LLM providers, but the frontend API client types were not updated. This caused the provider data to be silently dropped when sending/receiving API calls, making the providers appear non-functional in the UI.

## Test plan
- [ ] Select Google Gemini as provider, fill API key and model, save — verify values persist after reload
- [ ] Select Anthropic Claude as provider, fill API key and model, save — verify values persist after reload
- [ ] Create a new LLM config with Google/Anthropic — verify model name appears in config card list
- [ ] Run `npm run typecheck` — no errors
- [ ] Run `npm run build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)