### PR TITLE
Standardize config item block sizing across panels

### DIFF
--- a/src/components/BigQueryCredentialsManager.tsx
+++ b/src/components/BigQueryCredentialsManager.tsx
@@ -196,13 +196,13 @@ export const BigQueryCredentialsManager = ({ onSourceAdded }: BigQueryCredential
                 key={`${cred.type}-${cred.id}`}
                 className="group relative p-3 rounded-lg border transition-all bg-muted/30 border-muted hover:bg-muted/50"
               >
-                <div className="flex items-start gap-2">
-                  <Key className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
+                <div className="flex items-center gap-2">
+                  <Key className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium truncate">
                       {cred.type === 'bigquery' ? cred.name : cred.connectionLabel}
                     </p>
-                    <div className="flex items-center gap-2 mt-1">
+                    <div className="flex items-center gap-2 mt-1 flex-wrap">
                       {cred.type === 'bigquery' ? (
                         <>
                           <Badge variant="outline" className="text-xs">{cred.projectId || 'N/A'}</Badge>

--- a/src/components/ConnectionsPanel.tsx
+++ b/src/components/ConnectionsPanel.tsx
@@ -298,7 +298,7 @@ export function ConnectionsPanel() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 pt-6 pb-4 min-h-0">
+      <div className="flex-1 overflow-y-auto px-4 pt-6 pb-4">
         {loading ? (
           <div className="flex items-center justify-center h-32">
             <div className="text-center">

--- a/src/components/LLMPanel.tsx
+++ b/src/components/LLMPanel.tsx
@@ -547,7 +547,7 @@ export function LLMPanel({ hasEnvLlm, onConfigAdded }: LLMPanelProps = {}) {
             )}
 
             {configs.length === 0 ? (
-              <div className="flex flex-col items-center justify-center text-center p-4 border rounded-lg bg-muted/10">
+              <div className="flex flex-col items-center justify-center h-full text-center p-4">
                 <Bot className="h-12 w-12 text-muted-foreground mb-3" />
                 <p className="text-sm text-muted-foreground">{t("llmConfig.empty")}</p>
                 <p className="text-xs text-muted-foreground mt-2">{t("llmConfig.emptyHelp")}</p>

--- a/src/components/SourcesPanel.tsx
+++ b/src/components/SourcesPanel.tsx
@@ -224,13 +224,23 @@ export function SourcesPanel({ onAddSource, agentId, refreshTrigger, onSourceAct
                 >
                   <div className="flex items-center gap-2">
                     <FileText className={`h-4 w-4 flex-shrink-0 ${isActive ? 'text-primary' : 'text-muted-foreground'}`} />
-                    <div className="flex-1 min-w-0 flex items-center justify-between gap-2">
+                    <div className="flex-1 min-w-0">
                       <p className={`text-sm font-medium truncate ${isActive ? 'text-primary' : ''}`}>
                         {source.name}
                       </p>
-                      <Badge variant="outline" className="text-xs flex-shrink-0">
-                        {source.type}
-                      </Badge>
+                      <div className="flex items-center gap-2 mt-1 flex-wrap">
+                        <Badge variant="outline" className="text-xs flex-shrink-0">
+                          {source.type}
+                        </Badge>
+                        {source.createdAt && (
+                          <>
+                            <span className="text-xs text-muted-foreground/60 flex-shrink-0" aria-hidden>·</span>
+                            <span className="text-xs text-muted-foreground">
+                              {new Date(source.createdAt).toLocaleDateString()}
+                            </span>
+                          </>
+                        )}
+                      </div>
                     </div>
                     <div className="flex items-center gap-1">
                       <Button


### PR DESCRIPTION
## Changes

- **BigQueryCredentialsManager**: Changed flex alignment from `items-start` to `items-center` and removed extra margin on icon; added `flex-wrap` to badge container for better responsiveness
- **ConnectionsPanel**: Removed `min-h-0` constraint from scrollable container for consistent sizing
- **LLMPanel**: Simplified empty state styling by replacing border/background with `h-full` for better layout consistency
- **SourcesPanel**: Restructured source item layout to match other panels:
  - Moved badge and metadata into a separate flex container with `flex-wrap`
  - Added creation date display with separator
  - Improved vertical stacking of information

These changes ensure consistent block sizing and layout behavior across all settings panels.