### PR TITLE
fix: resolve no-explicit-any lint errors breaking CI

### DIFF
--- a/src/components/ExcelOnlineSourceForm.tsx
+++ b/src/components/ExcelOnlineSourceForm.tsx
@@ -116,7 +116,7 @@ export const ExcelOnlineSourceForm = forwardRef<ExcelOnlineSourceFormHandle, Exc
           sheetName,
         };
 
-        const source = await dataClient.createSource(name, 'excel_online' as any, metadata, undefined);
+        const source = await dataClient.createSource(name, 'excel_online', metadata, undefined);
         if (agentId && source?.id) {
           const existingSources = await dataClient.listSources(agentId);
           await Promise.all(

--- a/src/components/HubspotSourceForm.tsx
+++ b/src/components/HubspotSourceForm.tsx
@@ -52,9 +52,9 @@ export const HubspotSourceForm = forwardRef<HubspotSourceFormHandle, HubspotSour
         } catch {
           setObjectCounts(null);
         }
-      } catch (error: any) {
+      } catch (error) {
         setConnectionTested(false);
-        toast.error(t('addSource.hubspotConnectionFailed'), { description: error.message });
+        toast.error(t('addSource.hubspotConnectionFailed'), { description: error instanceof Error ? error.message : String(error) });
       } finally {
         setTestingConnection(false);
       }
@@ -74,13 +74,13 @@ export const HubspotSourceForm = forwardRef<HubspotSourceFormHandle, HubspotSour
           objectCounts: objectCounts || {},
         };
 
-        const source = await dataClient.createSource(name, 'hubspot' as any, metadata, undefined);
+        const source = await dataClient.createSource(name, 'hubspot', metadata, undefined);
         if (agentId && source?.id) {
           const existingSources = await dataClient.listSources(agentId);
           await Promise.all(
             existingSources
-              .filter((s: any) => s.id !== source.id && s.type !== 'sql_database')
-              .map((s: any) => dataClient.updateSource(s.id, { is_active: false }))
+              .filter((s: { id: string; type: string }) => s.id !== source.id && s.type !== 'sql_database')
+              .map((s: { id: string; type: string }) => dataClient.updateSource(s.id, { is_active: false }))
           );
           await dataClient.updateSource(source.id, { agent_id: agentId, is_active: true });
         }
@@ -91,9 +91,9 @@ export const HubspotSourceForm = forwardRef<HubspotSourceFormHandle, HubspotSour
         toast.success(t('addSource.hubspotConnectSuccess'));
         onSourceAdded?.(source.id);
         onClose();
-      } catch (error: any) {
+      } catch (error) {
         console.error('HubSpot connection error:', error);
-        toast.error(t('addSource.hubspotConnectError'), { description: error.message });
+        toast.error(t('addSource.hubspotConnectError'), { description: error instanceof Error ? error.message : String(error) });
       } finally {
         setConnecting(false);
       }

--- a/src/components/JiraSourceForm.tsx
+++ b/src/components/JiraSourceForm.tsx
@@ -66,9 +66,9 @@ export const JiraSourceForm = forwardRef<JiraSourceFormHandle, JiraSourceFormPro
         } finally {
           setLoadingDiscovery(false);
         }
-      } catch (error: any) {
+      } catch (error) {
         setConnectionTested(false);
-        toast.error(t('addSource.jiraConnectionFailed'), { description: error.message });
+        toast.error(t('addSource.jiraConnectionFailed'), { description: error instanceof Error ? error.message : String(error) });
       } finally {
         setTestingConnection(false);
       }
@@ -93,13 +93,13 @@ export const JiraSourceForm = forwardRef<JiraSourceFormHandle, JiraSourceFormPro
           boardCount: boards.length,
         };
 
-        const source = await dataClient.createSource(name, 'jira' as any, metadata, undefined);
+        const source = await dataClient.createSource(name, 'jira', metadata, undefined);
         if (agentId && source?.id) {
           const existingSources = await dataClient.listSources(agentId);
           await Promise.all(
             existingSources
-              .filter((s: any) => s.id !== source.id && s.type !== 'sql_database')
-              .map((s: any) => dataClient.updateSource(s.id, { is_active: false }))
+              .filter((s: { id: string; type: string }) => s.id !== source.id && s.type !== 'sql_database')
+              .map((s: { id: string; type: string }) => dataClient.updateSource(s.id, { is_active: false }))
           );
           await dataClient.updateSource(source.id, { agent_id: agentId, is_active: true });
         }
@@ -110,9 +110,9 @@ export const JiraSourceForm = forwardRef<JiraSourceFormHandle, JiraSourceFormPro
         toast.success(t('addSource.jiraConnectSuccess'));
         onSourceAdded?.(source.id);
         onClose();
-      } catch (error: any) {
+      } catch (error) {
         console.error('Jira connection error:', error);
-        toast.error(t('addSource.jiraConnectError'), { description: error.message });
+        toast.error(t('addSource.jiraConnectError'), { description: error instanceof Error ? error.message : String(error) });
       } finally {
         setConnecting(false);
       }

--- a/src/components/MongoDbSourceForm.tsx
+++ b/src/components/MongoDbSourceForm.tsx
@@ -120,7 +120,7 @@ export const MongoDbSourceForm = forwardRef<MongoDbSourceFormHandle, MongoDbSour
           collection: selectedCollection,
         };
 
-        const source = await dataClient.createSource(name, 'mongodb' as any, metadata, undefined);
+        const source = await dataClient.createSource(name, 'mongodb', metadata, undefined);
         if (agentId && source?.id) {
           const existingSources = await dataClient.listSources(agentId);
           await Promise.all(

--- a/src/components/NotionSourceForm.tsx
+++ b/src/components/NotionSourceForm.tsx
@@ -91,7 +91,7 @@ export const NotionSourceForm = forwardRef<NotionSourceFormHandle, NotionSourceF
           databaseTitle: dbTitle,
         };
 
-        const source = await dataClient.createSource(name, 'notion' as any, metadata, undefined);
+        const source = await dataClient.createSource(name, 'notion', metadata, undefined);
         if (agentId && source?.id) {
           const existingSources = await dataClient.listSources(agentId);
           await Promise.all(

--- a/src/components/RestApiSourceForm.tsx
+++ b/src/components/RestApiSourceForm.tsx
@@ -37,7 +37,7 @@ export const RestApiSourceForm = forwardRef<RestApiSourceFormHandle, RestApiSour
     const [dataPath, setDataPath] = useState("");
     const [testing, setTesting] = useState(false);
     const [tested, setTested] = useState(false);
-    const [previewData, setPreviewData] = useState<{ columns: string[]; preview: any[]; rowCount: number } | null>(null);
+    const [previewData, setPreviewData] = useState<{ columns: string[]; preview: Record<string, unknown>[]; rowCount: number } | null>(null);
 
     const canConnect = tested && !!url.trim();
 
@@ -83,7 +83,7 @@ export const RestApiSourceForm = forwardRef<RestApiSourceFormHandle, RestApiSour
           preview: previewData?.preview,
           rowCount: previewData?.rowCount,
         };
-        const source = await dataClient.createSource(name, 'rest_api' as any, metadata, undefined);
+        const source = await dataClient.createSource(name, 'rest_api', metadata, undefined);
         if (agentId && source?.id) {
           const existingSources = await dataClient.listSources(agentId);
           await Promise.all(

--- a/src/components/S3SourceForm.tsx
+++ b/src/components/S3SourceForm.tsx
@@ -83,12 +83,12 @@ export const S3SourceForm = forwardRef<S3SourceFormHandle, S3SourceFormProps>(
       if (!accessKeyId.trim() || !secretAccessKey.trim()) return;
       setTestingConnection(true);
       try {
-        await dataClient.s3TestConnection(creds as any);
+        await dataClient.s3TestConnection(creds);
         setConnectionTested(true);
         toast.success(t('addSource.s3ConnectionSuccess'));
         setLoadingBuckets(true);
         try {
-          const res = await dataClient.s3ListBuckets(creds as any);
+          const res = await dataClient.s3ListBuckets(creds);
           setBuckets(res.buckets || []);
         } catch { setBuckets([]); }
         finally { setLoadingBuckets(false); }
@@ -111,7 +111,7 @@ export const S3SourceForm = forwardRef<S3SourceFormHandle, S3SourceFormProps>(
           endpoint: endpoint || undefined,
           bucket: selectedBucket, key: selectedKey,
         };
-        const source = await dataClient.createSource(name, 's3' as any, metadata, undefined);
+        const source = await dataClient.createSource(name, 's3', metadata, undefined);
         if (agentId && source?.id) {
           const existingSources = await dataClient.listSources(agentId);
           await Promise.all(

--- a/src/components/SnowflakeSourceForm.tsx
+++ b/src/components/SnowflakeSourceForm.tsx
@@ -165,7 +165,7 @@ export const SnowflakeSourceForm = forwardRef<SnowflakeSourceFormHandle, Snowfla
           tables: selectedTables,
         };
 
-        const source = await dataClient.createSource(name, 'snowflake' as any, metadata, undefined);
+        const source = await dataClient.createSource(name, 'snowflake', metadata, undefined);
         if (agentId && source?.id) {
           const existingSources = await dataClient.listSources(agentId);
           await Promise.all(

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -103,7 +103,7 @@ export const apiClient = {
     return (data || []).map((s) => ({
       id: s.id,
       name: s.name,
-      type: s.type as 'csv' | 'xlsx' | 'bigquery' | 'google_sheets' | 'sql_database' | 'firebase',
+      type: s.type,
       ownerId: s.ownerId,
       agent_id: s.agent_id,
       is_active: s.is_active,
@@ -122,7 +122,7 @@ export const apiClient = {
     await api(`/api/sources/${id}`, { method: 'DELETE' });
   },
 
-  async createSource(name: string, type: 'bigquery' | 'google_sheets' | 'sql_database' | 'dbt' | 'github_file' | 'firebase', metadata: Record<string, unknown>, agentId?: string) {
+  async createSource(name: string, type: string, metadata: Record<string, unknown>, agentId?: string) {
     const data = await api<{ id: string; name: string; type: string; ownerId: string; createdAt: string; metaJSON: Record<string, unknown> }>('/api/sources', {
       method: 'POST',
       body: JSON.stringify({ name, type, metadata, agent_id: agentId ?? null }),


### PR DESCRIPTION
## Summary
- Widen `createSource` type parameter from restrictive union literal to `string`, eliminating the need for `as any` casts when adding new source types
- Remove all `as any` type casts in 8 source form components (HubSpot, Jira, S3, MongoDB, Notion, Snowflake, Excel Online, REST API)
- Replace `error: any` catch blocks with proper `error instanceof Error` handling
- Replace `(s: any)` array callbacks with explicit `{ id: string; type: string }` types
- Replace `any[]` with `Record<string, unknown>[]` in RestApiSourceForm

## Test plan
- [x] `npm run lint` passes with 0 errors (60 warnings, all pre-existing)
- [x] `npm run typecheck` passes
- [x] Frontend dev server starts without console errors
- [ ] CI pipeline should now pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)