### PR TITLE
revert: undo dataset border light mode fix

### DIFF
--- a/src/components/SourcesPanel.tsx
+++ b/src/components/SourcesPanel.tsx
@@ -200,9 +200,9 @@ export function SourcesPanel({ onAddSource, agentId, refreshTrigger, onSourceAct
                 <div
                   key={source.id}
                   className={`group relative p-3 rounded-lg border transition-all cursor-pointer ${
-                    isActive
-                      ? 'bg-primary/15 border-primary hover:bg-primary/20'
-                      : 'bg-muted/30 border-border hover:bg-muted/50'
+                    isActive 
+                      ? 'bg-primary/15 border-primary/30 hover:bg-primary/20' 
+                      : 'bg-muted/30 border-muted hover:bg-muted/50'
                   }`}
                   onClick={async () => {
                     if (agentId) {


### PR DESCRIPTION
## Summary

- Reverts the merge commit that changed dataset border styling in `SourcesPanel.tsx`
- The original fix was intended for a different repository

## Test plan

- [ ] Verify `SourcesPanel.tsx` is back to its original border classes (`border-primary/30` and `border-muted`)

https://claude.ai/code/session_01JV6RJN4sKqY5iPnaCmg9xy