### PR TITLE
feat: add walkthrough onboarding tutorial for first-time users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { LanguageProvider } from "@/contexts/LanguageContext";
+import { WalkthroughProvider } from "@/contexts/WalkthroughContext";
+import { WalkthroughOverlay } from "@/components/walkthrough/WalkthroughOverlay";
 import { useAuth } from "@/hooks/useAuth";
 import Account from "@/pages/Account";
 import AgentBriefing from "@/pages/AgentBriefing";
@@ -74,13 +76,16 @@ const AppContent = () => {
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <LanguageProvider>
-      <TooltipProvider>
-        <Toaster />
-        <Sonner />
-        <BrowserRouter>
-          <AppContent />
-        </BrowserRouter>
-      </TooltipProvider>
+      <WalkthroughProvider>
+        <TooltipProvider>
+          <Toaster />
+          <Sonner />
+          <BrowserRouter>
+            <AppContent />
+          </BrowserRouter>
+          <WalkthroughOverlay />
+        </TooltipProvider>
+      </WalkthroughProvider>
     </LanguageProvider>
   </QueryClientProvider>
 );

--- a/src/components/SourcesPanel.tsx
+++ b/src/components/SourcesPanel.tsx
@@ -166,6 +166,7 @@ export function SourcesPanel({ onAddSource, agentId, refreshTrigger, onSourceAct
             size="sm"
             onClick={onAddSource}
             disabled={false}
+            data-walkthrough="ws-add-source"
           >
             <Plus className="h-4 w-4 mr-2" />
             {t('sources.add')}

--- a/src/components/walkthrough/WalkthroughArrow.tsx
+++ b/src/components/walkthrough/WalkthroughArrow.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils';
+
+interface WalkthroughArrowProps {
+  direction: 'top' | 'bottom' | 'left' | 'right';
+  className?: string;
+}
+
+export function WalkthroughArrow({ direction, className }: WalkthroughArrowProps) {
+  return (
+    <div
+      className={cn(
+        'absolute w-0 h-0',
+        direction === 'top' && 'border-l-[10px] border-l-transparent border-r-[10px] border-r-transparent border-b-[10px] border-b-white -top-[10px] left-1/2 -translate-x-1/2',
+        direction === 'bottom' && 'border-l-[10px] border-l-transparent border-r-[10px] border-r-transparent border-t-[10px] border-t-white -bottom-[10px] left-1/2 -translate-x-1/2',
+        direction === 'left' && 'border-t-[10px] border-t-transparent border-b-[10px] border-b-transparent border-r-[10px] border-r-white -left-[10px] top-1/2 -translate-y-1/2',
+        direction === 'right' && 'border-t-[10px] border-t-transparent border-b-[10px] border-b-transparent border-l-[10px] border-l-white -right-[10px] top-1/2 -translate-y-1/2',
+        className,
+      )}
+    />
+  );
+}

--- a/src/components/walkthrough/WalkthroughOverlay.tsx
+++ b/src/components/walkthrough/WalkthroughOverlay.tsx
@@ -1,0 +1,232 @@
+import { useLanguage } from '@/contexts/LanguageContext';
+import { useWalkthrough } from '@/contexts/WalkthroughContext';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { WalkthroughTooltip } from './WalkthroughTooltip';
+
+const SPOTLIGHT_PADDING = 8;
+const SPOTLIGHT_RADIUS = 8;
+const TOOLTIP_GAP = 16;
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function getArrowDirection(position: 'top' | 'bottom' | 'left' | 'right') {
+  const map = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' } as const;
+  return map[position];
+}
+
+export function WalkthroughOverlay() {
+  const { isActive, currentStep, currentStepIndex, totalSteps, nextStep, prevStep, skipTour } = useWalkthrough();
+  const { t } = useLanguage();
+  const [targetRect, setTargetRect] = useState<Rect | null>(null);
+  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const [visible, setVisible] = useState(false);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number>(0);
+
+  const computePosition = useCallback(() => {
+    if (!currentStep) return;
+
+    const el = document.querySelector(`[data-walkthrough="${currentStep.target}"]`);
+    if (!el) return;
+
+    const rect = el.getBoundingClientRect();
+    const scrollTop = window.scrollY;
+    const scrollLeft = window.scrollX;
+
+    const padded: Rect = {
+      top: rect.top + scrollTop - SPOTLIGHT_PADDING,
+      left: rect.left + scrollLeft - SPOTLIGHT_PADDING,
+      width: rect.width + SPOTLIGHT_PADDING * 2,
+      height: rect.height + SPOTLIGHT_PADDING * 2,
+    };
+
+    setTargetRect(padded);
+
+    const tooltipW = 340;
+    const tooltipH = tooltipRef.current?.offsetHeight || 220;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    let top = 0;
+    let left = 0;
+
+    const centerX = padded.left + padded.width / 2;
+    const centerY = padded.top + padded.height / 2;
+
+    switch (currentStep.position) {
+      case 'bottom':
+        top = padded.top + padded.height + TOOLTIP_GAP;
+        left = centerX - tooltipW / 2;
+        break;
+      case 'top':
+        top = padded.top - tooltipH - TOOLTIP_GAP;
+        left = centerX - tooltipW / 2;
+        break;
+      case 'right':
+        top = centerY - tooltipH / 2;
+        left = padded.left + padded.width + TOOLTIP_GAP;
+        break;
+      case 'left':
+        top = centerY - tooltipH / 2;
+        left = padded.left - tooltipW - TOOLTIP_GAP;
+        break;
+    }
+
+    // Clamp to viewport
+    left = Math.max(12, Math.min(left, vw - tooltipW - 12 + scrollLeft));
+    top = Math.max(12 + scrollTop, Math.min(top, vh - tooltipH - 12 + scrollTop));
+
+    setTooltipPos({ top, left });
+  }, [currentStep]);
+
+  // Scroll target into view and compute position
+  useEffect(() => {
+    if (!isActive || !currentStep) {
+      setVisible(false);
+      return;
+    }
+
+    const el = document.querySelector(`[data-walkthrough="${currentStep.target}"]`);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    // Small delay after scroll to compute position
+    const timer = setTimeout(() => {
+      computePosition();
+      setVisible(true);
+    }, 350);
+
+    return () => clearTimeout(timer);
+  }, [isActive, currentStep, computePosition]);
+
+  // Update position on scroll/resize
+  useEffect(() => {
+    if (!isActive) return;
+
+    const handleUpdate = () => {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(computePosition);
+    };
+
+    window.addEventListener('scroll', handleUpdate, true);
+    window.addEventListener('resize', handleUpdate);
+    return () => {
+      window.removeEventListener('scroll', handleUpdate, true);
+      window.removeEventListener('resize', handleUpdate);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [isActive, computePosition]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!isActive) return;
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { skipTour(); return; }
+      if (e.key === 'ArrowRight' || e.key === 'Enter') { nextStep(); return; }
+      if (e.key === 'ArrowLeft') { prevStep(); return; }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isActive, nextStep, prevStep, skipTour]);
+
+  if (!isActive || !currentStep || !targetRect) return null;
+
+  const arrowDir = getArrowDirection(currentStep.position);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9998]"
+      style={{ pointerEvents: 'none' }}
+    >
+      {/* Spotlight overlay */}
+      <div
+        className="absolute transition-all duration-300 ease-in-out"
+        style={{
+          top: targetRect.top,
+          left: targetRect.left,
+          width: targetRect.width,
+          height: targetRect.height,
+          borderRadius: SPOTLIGHT_RADIUS,
+          boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.55)',
+          pointerEvents: 'none',
+          opacity: visible ? 1 : 0,
+        }}
+      />
+
+      {/* Click blocker (everywhere except spotlight) */}
+      <div
+        className="fixed inset-0"
+        style={{
+          pointerEvents: 'auto',
+          background: 'transparent',
+          clipPath: `polygon(
+            0% 0%, 0% 100%, 100% 100%, 100% 0%, 0% 0%,
+            ${targetRect.left}px ${targetRect.top}px,
+            ${targetRect.left}px ${targetRect.top + targetRect.height}px,
+            ${targetRect.left + targetRect.width}px ${targetRect.top + targetRect.height}px,
+            ${targetRect.left + targetRect.width}px ${targetRect.top}px,
+            ${targetRect.left}px ${targetRect.top}px
+          )`,
+        }}
+        onClick={skipTour}
+      />
+
+      {/* Pulsing ring around spotlight */}
+      <div
+        className="absolute border-2 border-emerald-400 transition-all duration-300 ease-in-out"
+        style={{
+          top: targetRect.top - 2,
+          left: targetRect.left - 2,
+          width: targetRect.width + 4,
+          height: targetRect.height + 4,
+          borderRadius: SPOTLIGHT_RADIUS + 2,
+          pointerEvents: 'none',
+          opacity: visible ? 1 : 0,
+          animation: 'walkthrough-pulse 2s ease-in-out infinite',
+        }}
+      />
+
+      {/* Tooltip */}
+      <div
+        ref={tooltipRef}
+        className="absolute z-[9999] transition-all duration-300 ease-in-out"
+        style={{
+          top: tooltipPos.top,
+          left: tooltipPos.left,
+          pointerEvents: 'auto',
+          opacity: visible ? 1 : 0,
+          transform: visible ? 'translateY(0)' : 'translateY(8px)',
+        }}
+      >
+        <WalkthroughTooltip
+          title={t(currentStep.titleKey)}
+          description={t(currentStep.descriptionKey)}
+          currentStep={currentStepIndex}
+          totalSteps={totalSteps}
+          arrowDirection={arrowDir}
+          onNext={nextStep}
+          onPrev={prevStep}
+          onSkip={skipTour}
+        />
+      </div>
+
+      {/* Global styles for pulse animation */}
+      <style>{`
+        @keyframes walkthrough-pulse {
+          0%, 100% { opacity: 0.6; transform: scale(1); }
+          50% { opacity: 1; transform: scale(1.01); }
+        }
+      `}</style>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/walkthrough/WalkthroughTooltip.tsx
+++ b/src/components/walkthrough/WalkthroughTooltip.tsx
@@ -1,0 +1,129 @@
+import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { cn } from '@/lib/utils';
+import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { WalkthroughArrow } from './WalkthroughArrow';
+
+interface WalkthroughTooltipProps {
+  title: string;
+  description: string;
+  currentStep: number;
+  totalSteps: number;
+  arrowDirection: 'top' | 'bottom' | 'left' | 'right';
+  onNext: () => void;
+  onPrev: () => void;
+  onSkip: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export function WalkthroughTooltip({
+  title,
+  description,
+  currentStep,
+  totalSteps,
+  arrowDirection,
+  onNext,
+  onPrev,
+  onSkip,
+  className,
+  style,
+}: WalkthroughTooltipProps) {
+  const { t } = useLanguage();
+  const isFirst = currentStep === 0;
+  const isLast = currentStep === totalSteps - 1;
+
+  return (
+    <div
+      className={cn(
+        'relative bg-white dark:bg-zinc-900 rounded-xl shadow-2xl border border-zinc-200 dark:border-zinc-700',
+        'w-[340px] max-w-[90vw] animate-in fade-in-0 slide-in-from-bottom-2 duration-300',
+        className,
+      )}
+      style={style}
+    >
+      <WalkthroughArrow direction={arrowDirection} />
+
+      {/* Header */}
+      <div className="flex items-start justify-between px-5 pt-4 pb-1">
+        <div className="flex items-center gap-2">
+          <div className="flex items-center justify-center w-7 h-7 rounded-full bg-emerald-100 dark:bg-emerald-900 text-emerald-700 dark:text-emerald-300 text-xs font-bold">
+            {currentStep + 1}
+          </div>
+          <span className="text-xs text-zinc-400 dark:text-zinc-500 font-medium">
+            {t('walkthrough.stepOf')
+              .replace('{current}', String(currentStep + 1))
+              .replace('{total}', String(totalSteps))}
+          </span>
+        </div>
+        <button
+          onClick={onSkip}
+          className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors p-0.5 rounded"
+          aria-label={t('walkthrough.skip')}
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="px-5 pb-3">
+        <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100 mb-1">
+          {title}
+        </h3>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed">
+          {description}
+        </p>
+      </div>
+
+      {/* Progress dots */}
+      <div className="flex items-center justify-center gap-1.5 pb-3">
+        {Array.from({ length: totalSteps }).map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              'rounded-full transition-all duration-300',
+              i === currentStep
+                ? 'w-5 h-2 bg-emerald-500'
+                : i < currentStep
+                  ? 'w-2 h-2 bg-emerald-300 dark:bg-emerald-700'
+                  : 'w-2 h-2 bg-zinc-200 dark:bg-zinc-700',
+            )}
+          />
+        ))}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between px-5 pb-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onSkip}
+          className="text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300 text-xs"
+        >
+          {t('walkthrough.skip')}
+        </Button>
+        <div className="flex items-center gap-2">
+          {!isFirst && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onPrev}
+              className="h-8 px-3 text-xs"
+            >
+              <ChevronLeft className="w-3.5 h-3.5 mr-1" />
+              {t('walkthrough.prev')}
+            </Button>
+          )}
+          <Button
+            size="sm"
+            onClick={onNext}
+            className="h-8 px-4 text-xs bg-emerald-600 hover:bg-emerald-700 text-white"
+          >
+            {isLast ? t('walkthrough.finish') : t('walkthrough.next')}
+            {!isLast && <ChevronRight className="w-3.5 h-3.5 ml-1" />}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/walkthrough/steps/accountSteps.ts
+++ b/src/components/walkthrough/steps/accountSteps.ts
@@ -1,0 +1,32 @@
+import { WalkthroughStep } from '../types';
+
+export const accountSteps: WalkthroughStep[] = [
+  {
+    id: 'overview',
+    target: 'account-sidebar',
+    titleKey: 'walkthrough.account.overview.title',
+    descriptionKey: 'walkthrough.account.overview.description',
+    position: 'right',
+  },
+  {
+    id: 'llm',
+    target: 'account-tab-llm',
+    titleKey: 'walkthrough.account.llm.title',
+    descriptionKey: 'walkthrough.account.llm.description',
+    position: 'right',
+  },
+  {
+    id: 'connections',
+    target: 'account-tab-connections',
+    titleKey: 'walkthrough.account.connections.title',
+    descriptionKey: 'walkthrough.account.connections.description',
+    position: 'right',
+  },
+  {
+    id: 'sources',
+    target: 'account-tab-sources',
+    titleKey: 'walkthrough.account.sources.title',
+    descriptionKey: 'walkthrough.account.sources.description',
+    position: 'right',
+  },
+];

--- a/src/components/walkthrough/steps/agentBriefingSteps.ts
+++ b/src/components/walkthrough/steps/agentBriefingSteps.ts
@@ -1,0 +1,33 @@
+import { WalkthroughStep } from '../types';
+
+export const agentBriefingSteps: WalkthroughStep[] = [
+  {
+    id: 'name-desc',
+    target: 'agent-name-section',
+    titleKey: 'walkthrough.agentBriefing.nameDesc.title',
+    descriptionKey: 'walkthrough.agentBriefing.nameDesc.description',
+    position: 'bottom',
+  },
+  {
+    id: 'sources',
+    target: 'agent-sources-section',
+    titleKey: 'walkthrough.agentBriefing.sources.title',
+    descriptionKey: 'walkthrough.agentBriefing.sources.description',
+    position: 'top',
+  },
+  {
+    id: 'suggested-questions',
+    target: 'agent-questions-section',
+    titleKey: 'walkthrough.agentBriefing.questions.title',
+    descriptionKey: 'walkthrough.agentBriefing.questions.description',
+    position: 'top',
+    optional: true,
+  },
+  {
+    id: 'save',
+    target: 'agent-save-btn',
+    titleKey: 'walkthrough.agentBriefing.save.title',
+    descriptionKey: 'walkthrough.agentBriefing.save.description',
+    position: 'top',
+  },
+];

--- a/src/components/walkthrough/steps/alertsSteps.ts
+++ b/src/components/walkthrough/steps/alertsSteps.ts
@@ -1,0 +1,27 @@
+import { WalkthroughStep } from '../types';
+
+export const alertsSteps: WalkthroughStep[] = [
+  {
+    id: 'overview',
+    target: 'alerts-header',
+    titleKey: 'walkthrough.alerts.overview.title',
+    descriptionKey: 'walkthrough.alerts.overview.description',
+    position: 'bottom',
+  },
+  {
+    id: 'create',
+    target: 'alerts-form',
+    titleKey: 'walkthrough.alerts.create.title',
+    descriptionKey: 'walkthrough.alerts.create.description',
+    position: 'right',
+    optional: true,
+  },
+  {
+    id: 'webhooks',
+    target: 'alerts-webhooks',
+    titleKey: 'walkthrough.alerts.webhooks.title',
+    descriptionKey: 'walkthrough.alerts.webhooks.description',
+    position: 'left',
+    optional: true,
+  },
+];

--- a/src/components/walkthrough/steps/dashboardSteps.ts
+++ b/src/components/walkthrough/steps/dashboardSteps.ts
@@ -1,0 +1,27 @@
+import { WalkthroughStep } from '../types';
+
+export const dashboardSteps: WalkthroughStep[] = [
+  {
+    id: 'overview',
+    target: 'dash-header',
+    titleKey: 'walkthrough.dashboard.overview.title',
+    descriptionKey: 'walkthrough.dashboard.overview.description',
+    position: 'bottom',
+  },
+  {
+    id: 'charts',
+    target: 'dash-charts-grid',
+    titleKey: 'walkthrough.dashboard.charts.title',
+    descriptionKey: 'walkthrough.dashboard.charts.description',
+    position: 'top',
+    optional: true,
+  },
+  {
+    id: 'actions',
+    target: 'dash-chart-actions',
+    titleKey: 'walkthrough.dashboard.actions.title',
+    descriptionKey: 'walkthrough.dashboard.actions.description',
+    position: 'left',
+    optional: true,
+  },
+];

--- a/src/components/walkthrough/steps/indexSteps.ts
+++ b/src/components/walkthrough/steps/indexSteps.ts
@@ -1,0 +1,33 @@
+import { WalkthroughStep } from '../types';
+
+export const indexSteps: WalkthroughStep[] = [
+  {
+    id: 'welcome',
+    target: 'index-hero',
+    titleKey: 'walkthrough.index.welcome.title',
+    descriptionKey: 'walkthrough.index.welcome.description',
+    position: 'bottom',
+  },
+  {
+    id: 'create-workspace',
+    target: 'index-create-btn',
+    titleKey: 'walkthrough.index.create.title',
+    descriptionKey: 'walkthrough.index.create.description',
+    position: 'bottom',
+  },
+  {
+    id: 'agent-cards',
+    target: 'index-agents-grid',
+    titleKey: 'walkthrough.index.agents.title',
+    descriptionKey: 'walkthrough.index.agents.description',
+    position: 'top',
+    optional: true,
+  },
+  {
+    id: 'view-sort',
+    target: 'index-view-controls',
+    titleKey: 'walkthrough.index.viewSort.title',
+    descriptionKey: 'walkthrough.index.viewSort.description',
+    position: 'bottom',
+  },
+];

--- a/src/components/walkthrough/steps/workspaceSteps.ts
+++ b/src/components/walkthrough/steps/workspaceSteps.ts
@@ -1,0 +1,56 @@
+import { WalkthroughStep } from '../types';
+
+export const workspaceSteps: WalkthroughStep[] = [
+  {
+    id: 'welcome',
+    target: 'ws-header',
+    titleKey: 'walkthrough.workspace.welcome.title',
+    descriptionKey: 'walkthrough.workspace.welcome.description',
+    position: 'bottom',
+  },
+  {
+    id: 'sources-panel',
+    target: 'ws-sources-panel',
+    titleKey: 'walkthrough.workspace.sources.title',
+    descriptionKey: 'walkthrough.workspace.sources.description',
+    position: 'right',
+  },
+  {
+    id: 'add-source',
+    target: 'ws-add-source',
+    titleKey: 'walkthrough.workspace.addSource.title',
+    descriptionKey: 'walkthrough.workspace.addSource.description',
+    position: 'right',
+    optional: true,
+  },
+  {
+    id: 'chat-input',
+    target: 'ws-chat-input',
+    titleKey: 'walkthrough.workspace.chatInput.title',
+    descriptionKey: 'walkthrough.workspace.chatInput.description',
+    position: 'top',
+  },
+  {
+    id: 'chat-area',
+    target: 'ws-chat-area',
+    titleKey: 'walkthrough.workspace.chatArea.title',
+    descriptionKey: 'walkthrough.workspace.chatArea.description',
+    position: 'bottom',
+    optional: true,
+  },
+  {
+    id: 'studio-panel',
+    target: 'ws-studio-panel',
+    titleKey: 'walkthrough.workspace.studio.title',
+    descriptionKey: 'walkthrough.workspace.studio.description',
+    position: 'left',
+    optional: true,
+  },
+  {
+    id: 'history',
+    target: 'ws-history-btn',
+    titleKey: 'walkthrough.workspace.history.title',
+    descriptionKey: 'walkthrough.workspace.history.description',
+    position: 'bottom',
+  },
+];

--- a/src/components/walkthrough/types.ts
+++ b/src/components/walkthrough/types.ts
@@ -1,0 +1,20 @@
+export interface WalkthroughStep {
+  id: string;
+  target: string;
+  titleKey: string;
+  descriptionKey: string;
+  position: 'top' | 'bottom' | 'left' | 'right';
+  optional?: boolean;
+}
+
+export interface WalkthroughState {
+  completedPages: Record<string, boolean>;
+  globallySkipped: boolean;
+}
+
+export const WALKTHROUGH_STORAGE_KEY = 'dt_walkthrough';
+
+export const defaultWalkthroughState: WalkthroughState = {
+  completedPages: {},
+  globallySkipped: false,
+};

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1470,6 +1470,75 @@ const translations = {
       'dashboard.chartUpdateSuccess': 'Chart updated successfully!',
       'dashboard.chartUpdateError': 'Error updating chart',
       'dashboard.chartLoadError': 'Could not load chart image',
+
+      // Walkthrough
+      'walkthrough.stepOf': '{current} of {total}',
+      'walkthrough.skip': 'Skip tutorial',
+      'walkthrough.next': 'Next',
+      'walkthrough.prev': 'Back',
+      'walkthrough.finish': 'Finish',
+
+      // Walkthrough — Index
+      'walkthrough.index.welcome.title': 'Welcome to Data Talks!',
+      'walkthrough.index.welcome.description': 'This is your home page where you manage all your workspaces. Each workspace is a separate data analysis environment.',
+      'walkthrough.index.create.title': 'Create a workspace',
+      'walkthrough.index.create.description': 'Click here to create a new workspace and start analyzing your data with AI.',
+      'walkthrough.index.agents.title': 'Your workspaces',
+      'walkthrough.index.agents.description': 'Your workspaces will appear here. Click on any card to open it and start asking questions.',
+      'walkthrough.index.viewSort.title': 'View & sort',
+      'walkthrough.index.viewSort.description': 'Switch between grid and list views, or sort your workspaces by date or name.',
+
+      // Walkthrough — Workspace
+      'walkthrough.workspace.welcome.title': 'Your workspace',
+      'walkthrough.workspace.welcome.description': 'This is the main area for data analysis. Here you connect data sources and ask questions in natural language.',
+      'walkthrough.workspace.sources.title': 'Data sources',
+      'walkthrough.workspace.sources.description': 'Your connected data sources appear in this panel. You can have CSV files, databases, Google Sheets, and more.',
+      'walkthrough.workspace.addSource.title': 'Add a data source',
+      'walkthrough.workspace.addSource.description': 'Click here to connect a new data source — upload a CSV, connect to a database, BigQuery, or Google Sheets.',
+      'walkthrough.workspace.chatInput.title': 'Ask a question',
+      'walkthrough.workspace.chatInput.description': 'Type your questions here in natural language. For example: "What were the top 5 products by revenue last month?"',
+      'walkthrough.workspace.chatArea.title': 'AI responses',
+      'walkthrough.workspace.chatArea.description': 'The AI responses with text, tables, and charts will appear here. You can also see follow-up suggestions.',
+      'walkthrough.workspace.studio.title': 'Tools & integrations',
+      'walkthrough.workspace.studio.description': 'Use these tools to generate reports, summaries, audio overviews, and connect to Slack, Telegram, or WhatsApp.',
+      'walkthrough.workspace.history.title': 'Conversation history',
+      'walkthrough.workspace.history.description': 'Access your previous conversations and resume them anytime.',
+
+      // Walkthrough — Dashboard
+      'walkthrough.dashboard.overview.title': 'Your dashboard',
+      'walkthrough.dashboard.overview.description': 'Dashboards display your saved charts in a visual layout. Organize your most important visualizations here.',
+      'walkthrough.dashboard.charts.title': 'Chart cards',
+      'walkthrough.dashboard.charts.description': 'Each card shows a chart from your analysis sessions. Add charts from the workspace to build your dashboard.',
+      'walkthrough.dashboard.actions.title': 'Chart actions',
+      'walkthrough.dashboard.actions.description': 'Edit titles, descriptions, or remove charts using the menu on each card.',
+
+      // Walkthrough — Agent Briefing
+      'walkthrough.agentBriefing.nameDesc.title': 'Name your agent',
+      'walkthrough.agentBriefing.nameDesc.description': 'Give your agent a name and description so you can easily identify it later.',
+      'walkthrough.agentBriefing.sources.title': 'Select data sources',
+      'walkthrough.agentBriefing.sources.description': 'Choose which data sources this agent will have access to for answering questions.',
+      'walkthrough.agentBriefing.questions.title': 'Suggested questions',
+      'walkthrough.agentBriefing.questions.description': 'Add suggested questions that will appear as quick-start prompts when users open this workspace.',
+      'walkthrough.agentBriefing.save.title': 'Save your agent',
+      'walkthrough.agentBriefing.save.description': 'When you are done configuring, click save to create or update your agent.',
+
+      // Walkthrough — Account
+      'walkthrough.account.overview.title': 'Settings',
+      'walkthrough.account.overview.description': 'Manage your account settings, AI model configuration, connections, and more from this sidebar.',
+      'walkthrough.account.llm.title': 'AI model settings',
+      'walkthrough.account.llm.description': 'Configure which AI model (OpenAI, Ollama, or LiteLLM) is used for your data analysis.',
+      'walkthrough.account.connections.title': 'Connections',
+      'walkthrough.account.connections.description': 'Manage your database and API connections here.',
+      'walkthrough.account.sources.title': 'Data sources',
+      'walkthrough.account.sources.description': 'View and manage all your connected data sources across workspaces.',
+
+      // Walkthrough — Alerts
+      'walkthrough.alerts.overview.title': 'Alerts',
+      'walkthrough.alerts.overview.description': 'Set up automated alerts to monitor your data and receive notifications by email or webhook.',
+      'walkthrough.alerts.create.title': 'Create an alert',
+      'walkthrough.alerts.create.description': 'Define what to monitor, how often to check, and where to send notifications.',
+      'walkthrough.alerts.webhooks.title': 'Webhooks',
+      'walkthrough.alerts.webhooks.description': 'Configure webhook URLs for advanced integrations with external tools.',
    },
   pt: {
     // Common
@@ -2929,6 +2998,75 @@ const translations = {
       'dashboard.chartUpdateSuccess': 'Gráfico atualizado com sucesso!',
       'dashboard.chartUpdateError': 'Erro ao atualizar gráfico',
       'dashboard.chartLoadError': 'Nao foi possivel carregar a imagem do grafico',
+
+      // Walkthrough
+      'walkthrough.stepOf': '{current} de {total}',
+      'walkthrough.skip': 'Pular tutorial',
+      'walkthrough.next': 'Proximo',
+      'walkthrough.prev': 'Voltar',
+      'walkthrough.finish': 'Concluir',
+
+      // Walkthrough — Index
+      'walkthrough.index.welcome.title': 'Bem-vindo ao Data Talks!',
+      'walkthrough.index.welcome.description': 'Esta e sua pagina inicial onde voce gerencia todos os seus workspaces. Cada workspace e um ambiente separado de analise de dados.',
+      'walkthrough.index.create.title': 'Crie um workspace',
+      'walkthrough.index.create.description': 'Clique aqui para criar um novo workspace e comecar a analisar seus dados com IA.',
+      'walkthrough.index.agents.title': 'Seus workspaces',
+      'walkthrough.index.agents.description': 'Seus workspaces aparecerao aqui. Clique em qualquer card para abri-lo e comecar a fazer perguntas.',
+      'walkthrough.index.viewSort.title': 'Visualizacao e ordenacao',
+      'walkthrough.index.viewSort.description': 'Alterne entre visualizacao em grade e lista, ou ordene seus workspaces por data ou nome.',
+
+      // Walkthrough — Workspace
+      'walkthrough.workspace.welcome.title': 'Seu workspace',
+      'walkthrough.workspace.welcome.description': 'Esta e a area principal de analise de dados. Aqui voce conecta fontes de dados e faz perguntas em linguagem natural.',
+      'walkthrough.workspace.sources.title': 'Fontes de dados',
+      'walkthrough.workspace.sources.description': 'Suas fontes de dados conectadas aparecem neste painel. Voce pode ter arquivos CSV, bancos de dados, Google Sheets e mais.',
+      'walkthrough.workspace.addSource.title': 'Adicionar fonte de dados',
+      'walkthrough.workspace.addSource.description': 'Clique aqui para conectar uma nova fonte — envie um CSV, conecte a um banco de dados, BigQuery ou Google Sheets.',
+      'walkthrough.workspace.chatInput.title': 'Faca uma pergunta',
+      'walkthrough.workspace.chatInput.description': 'Digite suas perguntas aqui em linguagem natural. Ex: "Quais foram os 5 principais produtos por receita no ultimo mes?"',
+      'walkthrough.workspace.chatArea.title': 'Respostas da IA',
+      'walkthrough.workspace.chatArea.description': 'As respostas da IA com texto, tabelas e graficos aparecerao aqui. Voce tambem vera sugestoes de perguntas.',
+      'walkthrough.workspace.studio.title': 'Ferramentas e integracoes',
+      'walkthrough.workspace.studio.description': 'Use estas ferramentas para gerar relatorios, resumos, audio e conectar ao Slack, Telegram ou WhatsApp.',
+      'walkthrough.workspace.history.title': 'Historico de conversas',
+      'walkthrough.workspace.history.description': 'Acesse suas conversas anteriores e retome-as a qualquer momento.',
+
+      // Walkthrough — Dashboard
+      'walkthrough.dashboard.overview.title': 'Seu dashboard',
+      'walkthrough.dashboard.overview.description': 'Dashboards exibem seus graficos salvos em um layout visual. Organize suas visualizacoes mais importantes aqui.',
+      'walkthrough.dashboard.charts.title': 'Cards de graficos',
+      'walkthrough.dashboard.charts.description': 'Cada card mostra um grafico de suas sessoes de analise. Adicione graficos do workspace para montar seu dashboard.',
+      'walkthrough.dashboard.actions.title': 'Acoes do grafico',
+      'walkthrough.dashboard.actions.description': 'Edite titulos, descricoes ou remova graficos usando o menu em cada card.',
+
+      // Walkthrough — Agent Briefing
+      'walkthrough.agentBriefing.nameDesc.title': 'Nomeie seu agente',
+      'walkthrough.agentBriefing.nameDesc.description': 'De um nome e descricao ao seu agente para identifica-lo facilmente depois.',
+      'walkthrough.agentBriefing.sources.title': 'Selecione fontes de dados',
+      'walkthrough.agentBriefing.sources.description': 'Escolha quais fontes de dados este agente tera acesso para responder perguntas.',
+      'walkthrough.agentBriefing.questions.title': 'Perguntas sugeridas',
+      'walkthrough.agentBriefing.questions.description': 'Adicione perguntas sugeridas que aparecerao como atalhos quando usuarios abrirem este workspace.',
+      'walkthrough.agentBriefing.save.title': 'Salvar agente',
+      'walkthrough.agentBriefing.save.description': 'Quando terminar de configurar, clique em salvar para criar ou atualizar seu agente.',
+
+      // Walkthrough — Account
+      'walkthrough.account.overview.title': 'Configuracoes',
+      'walkthrough.account.overview.description': 'Gerencie suas configuracoes de conta, modelo de IA, conexoes e mais nesta barra lateral.',
+      'walkthrough.account.llm.title': 'Configuracoes do modelo de IA',
+      'walkthrough.account.llm.description': 'Configure qual modelo de IA (OpenAI, Ollama ou LiteLLM) sera usado para sua analise de dados.',
+      'walkthrough.account.connections.title': 'Conexoes',
+      'walkthrough.account.connections.description': 'Gerencie suas conexoes com bancos de dados e APIs aqui.',
+      'walkthrough.account.sources.title': 'Fontes de dados',
+      'walkthrough.account.sources.description': 'Visualize e gerencie todas as suas fontes de dados conectadas em todos os workspaces.',
+
+      // Walkthrough — Alerts
+      'walkthrough.alerts.overview.title': 'Alertas',
+      'walkthrough.alerts.overview.description': 'Configure alertas automatizados para monitorar seus dados e receber notificacoes por e-mail ou webhook.',
+      'walkthrough.alerts.create.title': 'Criar um alerta',
+      'walkthrough.alerts.create.description': 'Defina o que monitorar, com que frequencia verificar e para onde enviar notificacoes.',
+      'walkthrough.alerts.webhooks.title': 'Webhooks',
+      'walkthrough.alerts.webhooks.description': 'Configure URLs de webhook para integracoes avancadas com ferramentas externas.',
    },
   es: {
     // Common
@@ -4357,6 +4495,76 @@ const translations = {
     'dashboard.chartUpdateSuccess': '¡Gráfico actualizado exitosamente!',
     'dashboard.chartUpdateError': 'Error al actualizar gráfico',
     'dashboard.chartLoadError': 'No se pudo cargar la imagen del grafico',
+
+    // Walkthrough
+    'walkthrough.stepOf': '{current} de {total}',
+    'walkthrough.skip': 'Saltar tutorial',
+    'walkthrough.next': 'Siguiente',
+    'walkthrough.prev': 'Atras',
+    'walkthrough.finish': 'Finalizar',
+
+    // Walkthrough — Index
+    'walkthrough.index.welcome.title': 'Bienvenido a Data Talks!',
+    'walkthrough.index.welcome.description': 'Esta es tu pagina de inicio donde gestionas todos tus workspaces. Cada workspace es un entorno separado de analisis de datos.',
+    'walkthrough.index.create.title': 'Crea un workspace',
+    'walkthrough.index.create.description': 'Haz clic aqui para crear un nuevo workspace y comenzar a analizar tus datos con IA.',
+    'walkthrough.index.agents.title': 'Tus workspaces',
+    'walkthrough.index.agents.description': 'Tus workspaces apareceran aqui. Haz clic en cualquier tarjeta para abrirlo y comenzar a hacer preguntas.',
+    'walkthrough.index.viewSort.title': 'Vista y orden',
+    'walkthrough.index.viewSort.description': 'Alterna entre vista de cuadricula y lista, u ordena tus workspaces por fecha o nombre.',
+
+    // Walkthrough — Workspace
+    'walkthrough.workspace.welcome.title': 'Tu workspace',
+    'walkthrough.workspace.welcome.description': 'Esta es el area principal de analisis de datos. Aqui conectas fuentes de datos y haces preguntas en lenguaje natural.',
+    'walkthrough.workspace.sources.title': 'Fuentes de datos',
+    'walkthrough.workspace.sources.description': 'Tus fuentes de datos conectadas aparecen en este panel. Puedes tener archivos CSV, bases de datos, Google Sheets y mas.',
+    'walkthrough.workspace.addSource.title': 'Agregar fuente de datos',
+    'walkthrough.workspace.addSource.description': 'Haz clic aqui para conectar una nueva fuente — sube un CSV, conecta a una base de datos, BigQuery o Google Sheets.',
+    'walkthrough.workspace.chatInput.title': 'Haz una pregunta',
+    'walkthrough.workspace.chatInput.description': 'Escribe tus preguntas aqui en lenguaje natural. Ej: "Cuales fueron los 5 principales productos por ingresos el mes pasado?"',
+    'walkthrough.workspace.chatArea.title': 'Respuestas de la IA',
+    'walkthrough.workspace.chatArea.description': 'Las respuestas de la IA con texto, tablas y graficos apareceran aqui. Tambien veras sugerencias de preguntas.',
+    'walkthrough.workspace.studio.title': 'Herramientas e integraciones',
+    'walkthrough.workspace.studio.description': 'Usa estas herramientas para generar informes, resumenes, audio y conectar con Slack, Telegram o WhatsApp.',
+    'walkthrough.workspace.history.title': 'Historial de conversaciones',
+    'walkthrough.workspace.history.description': 'Accede a tus conversaciones anteriores y retormalas en cualquier momento.',
+
+    // Walkthrough — Dashboard
+    'walkthrough.dashboard.overview.title': 'Tu dashboard',
+    'walkthrough.dashboard.overview.description': 'Los dashboards muestran tus graficos guardados en un diseno visual. Organiza tus visualizaciones mas importantes aqui.',
+    'walkthrough.dashboard.charts.title': 'Tarjetas de graficos',
+    'walkthrough.dashboard.charts.description': 'Cada tarjeta muestra un grafico de tus sesiones de analisis. Agrega graficos del workspace para armar tu dashboard.',
+    'walkthrough.dashboard.actions.title': 'Acciones del grafico',
+    'walkthrough.dashboard.actions.description': 'Edita titulos, descripciones o elimina graficos usando el menu de cada tarjeta.',
+
+    // Walkthrough — Agent Briefing
+    'walkthrough.agentBriefing.nameDesc.title': 'Nombra tu agente',
+    'walkthrough.agentBriefing.nameDesc.description': 'Dale un nombre y descripcion a tu agente para identificarlo facilmente despues.',
+    'walkthrough.agentBriefing.sources.title': 'Selecciona fuentes de datos',
+    'walkthrough.agentBriefing.sources.description': 'Elige a que fuentes de datos tendra acceso este agente para responder preguntas.',
+    'walkthrough.agentBriefing.questions.title': 'Preguntas sugeridas',
+    'walkthrough.agentBriefing.questions.description': 'Agrega preguntas sugeridas que apareceran como atajos cuando los usuarios abran este workspace.',
+    'walkthrough.agentBriefing.save.title': 'Guardar agente',
+    'walkthrough.agentBriefing.save.description': 'Cuando termines de configurar, haz clic en guardar para crear o actualizar tu agente.',
+
+    // Walkthrough — Account
+    'walkthrough.account.overview.title': 'Configuraciones',
+    'walkthrough.account.overview.description': 'Gestiona la configuracion de tu cuenta, modelo de IA, conexiones y mas desde esta barra lateral.',
+    'walkthrough.account.llm.title': 'Configuracion del modelo de IA',
+    'walkthrough.account.llm.description': 'Configura que modelo de IA (OpenAI, Ollama o LiteLLM) se usara para tu analisis de datos.',
+    'walkthrough.account.connections.title': 'Conexiones',
+    'walkthrough.account.connections.description': 'Gestiona tus conexiones a bases de datos y APIs aqui.',
+    'walkthrough.account.sources.title': 'Fuentes de datos',
+    'walkthrough.account.sources.description': 'Visualiza y gestiona todas tus fuentes de datos conectadas en todos los workspaces.',
+
+    // Walkthrough — Alerts
+    'walkthrough.alerts.overview.title': 'Alertas',
+    'walkthrough.alerts.overview.description': 'Configura alertas automatizadas para monitorear tus datos y recibir notificaciones por correo o webhook.',
+    'walkthrough.alerts.create.title': 'Crear una alerta',
+    'walkthrough.alerts.create.description': 'Define que monitorear, con que frecuencia verificar y donde enviar notificaciones.',
+    'walkthrough.alerts.webhooks.title': 'Webhooks',
+    'walkthrough.alerts.webhooks.description': 'Configura URLs de webhook para integraciones avanzadas con herramientas externas.',
+
     // Footer
     'footer.copyright': '© {year} Habla con tus datos. Todos los derechos reservados.',
   }

--- a/src/contexts/WalkthroughContext.tsx
+++ b/src/contexts/WalkthroughContext.tsx
@@ -1,0 +1,186 @@
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import {
+  WalkthroughStep,
+  WalkthroughState,
+  WALKTHROUGH_STORAGE_KEY,
+  defaultWalkthroughState,
+} from '@/components/walkthrough/types';
+
+interface WalkthroughContextType {
+  isActive: boolean;
+  currentStepIndex: number;
+  currentStep: WalkthroughStep | null;
+  steps: WalkthroughStep[];
+  totalSteps: number;
+  startTour: (pageId: string, steps: WalkthroughStep[]) => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  skipTour: () => void;
+  finishTour: () => void;
+  isPageCompleted: (pageId: string) => boolean;
+  resetPage: (pageId: string) => void;
+  resetAll: () => void;
+}
+
+const WalkthroughContext = createContext<WalkthroughContextType | undefined>(undefined);
+
+function loadState(): WalkthroughState {
+  try {
+    const raw = localStorage.getItem(WALKTHROUGH_STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    // Ignore parse errors, return default
+  }
+  return { ...defaultWalkthroughState };
+}
+
+function saveState(state: WalkthroughState) {
+  try {
+    localStorage.setItem(WALKTHROUGH_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export const WalkthroughProvider = ({ children }: { children: ReactNode }) => {
+  const [persistedState, setPersistedState] = useState<WalkthroughState>(loadState);
+  const [isActive, setIsActive] = useState(false);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [steps, setSteps] = useState<WalkthroughStep[]>([]);
+  const [activePageId, setActivePageId] = useState<string | null>(null);
+  const activeSteps = useRef<WalkthroughStep[]>([]);
+
+  const updatePersistedState = useCallback((updater: (prev: WalkthroughState) => WalkthroughState) => {
+    setPersistedState(prev => {
+      const next = updater(prev);
+      saveState(next);
+      return next;
+    });
+  }, []);
+
+  const resolveVisibleSteps = useCallback((allSteps: WalkthroughStep[]): WalkthroughStep[] => {
+    return allSteps.filter(step => {
+      const el = document.querySelector(`[data-walkthrough="${step.target}"]`);
+      if (!el) return !step.optional ? false : false;
+      const rect = el.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    });
+  }, []);
+
+  const startTour = useCallback((pageId: string, tourSteps: WalkthroughStep[]) => {
+    if (persistedState.globallySkipped) return;
+    if (persistedState.completedPages[pageId]) return;
+    if (isActive) return;
+
+    const visible = resolveVisibleSteps(tourSteps);
+    if (visible.length === 0) return;
+
+    activeSteps.current = visible;
+    setSteps(visible);
+    setCurrentStepIndex(0);
+    setActivePageId(pageId);
+    setIsActive(true);
+  }, [persistedState, isActive, resolveVisibleSteps]);
+
+  const markPageComplete = useCallback((pageId: string) => {
+    updatePersistedState(prev => ({
+      ...prev,
+      completedPages: { ...prev.completedPages, [pageId]: true },
+    }));
+  }, [updatePersistedState]);
+
+  const finishTour = useCallback(() => {
+    if (activePageId) markPageComplete(activePageId);
+    setIsActive(false);
+    setSteps([]);
+    setCurrentStepIndex(0);
+    setActivePageId(null);
+  }, [activePageId, markPageComplete]);
+
+  const skipTour = useCallback(() => {
+    if (activePageId) markPageComplete(activePageId);
+    updatePersistedState(prev => ({ ...prev, globallySkipped: true }));
+    setIsActive(false);
+    setSteps([]);
+    setCurrentStepIndex(0);
+    setActivePageId(null);
+  }, [activePageId, markPageComplete, updatePersistedState]);
+
+  const nextStep = useCallback(() => {
+    if (currentStepIndex < steps.length - 1) {
+      setCurrentStepIndex(prev => prev + 1);
+    } else {
+      finishTour();
+    }
+  }, [currentStepIndex, steps.length, finishTour]);
+
+  const prevStep = useCallback(() => {
+    if (currentStepIndex > 0) {
+      setCurrentStepIndex(prev => prev - 1);
+    }
+  }, [currentStepIndex]);
+
+  const isPageCompleted = useCallback((pageId: string) => {
+    return persistedState.completedPages[pageId] === true || persistedState.globallySkipped;
+  }, [persistedState]);
+
+  const resetPage = useCallback((pageId: string) => {
+    updatePersistedState(prev => {
+      const next = { ...prev.completedPages };
+      delete next[pageId];
+      return { ...prev, completedPages: next };
+    });
+  }, [updatePersistedState]);
+
+  const resetAll = useCallback(() => {
+    updatePersistedState(() => ({ ...defaultWalkthroughState }));
+  }, [updatePersistedState]);
+
+  const currentStep = isActive && steps[currentStepIndex] ? steps[currentStepIndex] : null;
+
+  return (
+    <WalkthroughContext.Provider
+      value={{
+        isActive,
+        currentStepIndex,
+        currentStep,
+        steps,
+        totalSteps: steps.length,
+        startTour,
+        nextStep,
+        prevStep,
+        skipTour,
+        finishTour,
+        isPageCompleted,
+        resetPage,
+        resetAll,
+      }}
+    >
+      {children}
+    </WalkthroughContext.Provider>
+  );
+};
+
+export function useWalkthrough() {
+  const ctx = useContext(WalkthroughContext);
+  if (!ctx) throw new Error('useWalkthrough must be used within WalkthroughProvider');
+  return ctx;
+}
+
+export function usePageWalkthrough(pageId: string, tourSteps: WalkthroughStep[]) {
+  const { startTour, isPageCompleted, isActive } = useWalkthrough();
+  const hasTriggered = useRef(false);
+
+  useEffect(() => {
+    if (hasTriggered.current) return;
+    if (isPageCompleted(pageId)) return;
+    if (isActive) return;
+
+    hasTriggered.current = true;
+    const timer = setTimeout(() => {
+      startTour(pageId, tourSteps);
+    }, 800);
+
+    return () => clearTimeout(timer);
+  }, [pageId, tourSteps, startTour, isPageCompleted, isActive]);
+}

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -14,6 +14,8 @@ import { ConnectionsPanel } from "@/components/ConnectionsPanel";
 import AuditTrail from "@/components/AuditTrail";
 import { useSearchParams } from "react-router-dom";
 import { dataClient } from "@/services/dataClient";
+import { usePageWalkthrough } from "@/contexts/WalkthroughContext";
+import { accountSteps } from "@/components/walkthrough/steps/accountSteps";
 
 const Account = () => {
   const { t } = useLanguage();
@@ -23,6 +25,7 @@ const Account = () => {
   const [showAddSourceModal, setShowAddSourceModal] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [hasEnvLlm, setHasEnvLlm] = useState<boolean | null>(null);
+  usePageWalkthrough('account', accountSteps);
 
   useEffect(() => {
     dataClient.getLlmStatus().then(s => setHasEnvLlm(s.has_env)).catch(() => setHasEnvLlm(false));
@@ -71,7 +74,7 @@ const Account = () => {
 
         {/* Grid: uma linha com altura total = as duas colunas sempre na mesma altura */}
         <div className="grid grid-cols-[14rem_1fr] sm:grid-cols-[16rem_1fr] grid-rows-[minmax(0,1fr)] gap-4 flex-1 min-h-0 overflow-hidden">
-          <div className="min-h-0 flex flex-col overflow-hidden">
+          <div className="min-h-0 flex flex-col overflow-hidden" data-walkthrough="account-sidebar">
             <div className="flex-1 min-h-0 bg-background border rounded-lg p-1.5 flex flex-col">
               <div className="space-y-0.5">
                 {menuItems.map((item) => {
@@ -86,6 +89,7 @@ const Account = () => {
                           ? "bg-primary/10 border border-primary/20 text-primary font-medium"
                           : "hover:bg-muted/50 text-muted-foreground"
                       )}
+                      {...(item.id === 'llm' ? { 'data-walkthrough': 'account-tab-llm' } : item.id === 'connections' ? { 'data-walkthrough': 'account-tab-connections' } : item.id === 'sources' ? { 'data-walkthrough': 'account-tab-sources' } : {})}
                     >
                       <Icon className="h-4 w-4 flex-shrink-0" />
                       <span className="text-sm">{item.label}</span>

--- a/src/pages/AgentBriefing.tsx
+++ b/src/pages/AgentBriefing.tsx
@@ -14,6 +14,8 @@ import { Badge } from "@/components/ui/badge";
 import { agentClient, Agent, Source } from "@/services/agentClient";
 import { dataClient } from "@/services/dataClient";
 import { useAuth } from "@/hooks/useAuth";
+import { usePageWalkthrough } from "@/contexts/WalkthroughContext";
+import { agentBriefingSteps } from "@/components/walkthrough/steps/agentBriefingSteps";
 
 export default function AgentBriefing() {
   const { id } = useParams();
@@ -30,6 +32,7 @@ export default function AgentBriefing() {
 
   const isEditing = !!id;
   const isCreating = !isEditing;
+  usePageWalkthrough('agentBriefing', agentBriefingSteps);
 
   useEffect(() => {
     loadData();
@@ -192,14 +195,14 @@ export default function AgentBriefing() {
               Remover
             </Button>
           )}
-          <Button onClick={handleSave} disabled={saving}>
+          <Button onClick={handleSave} disabled={saving} data-walkthrough="agent-save-btn">
             {saving ? 'Salvando...' : isEditing ? 'Atualizar' : 'Criar'}
           </Button>
         </div>
       </div>
 
       <div className="grid gap-6">
-        <Card>
+        <Card data-walkthrough="agent-name-section">
           <CardHeader>
             <CardTitle>Informações Básicas</CardTitle>
             <CardDescription>
@@ -230,7 +233,7 @@ export default function AgentBriefing() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card data-walkthrough="agent-sources-section">
           <CardHeader>
             <CardTitle>Fontes de Dados</CardTitle>
             <CardDescription>
@@ -271,7 +274,7 @@ export default function AgentBriefing() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card data-walkthrough="agent-questions-section">
           <CardHeader>
             <CardTitle>Perguntas Sugeridas</CardTitle>
             <CardDescription>

--- a/src/pages/Alerts.tsx
+++ b/src/pages/Alerts.tsx
@@ -9,6 +9,8 @@ import { useToast } from "@/hooks/use-toast";
 import { dataClient } from "@/services/dataClient";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import { usePageWalkthrough } from "@/contexts/WalkthroughContext";
+import { alertsSteps } from "@/components/walkthrough/steps/alertsSteps";
 
 const Alerts = () => {
   const { t } = useLanguage();
@@ -32,6 +34,7 @@ const Alerts = () => {
 
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  usePageWalkthrough('alerts', alertsSteps);
 
   const { data: agents = [] } = useQuery({
     queryKey: ['agents'],
@@ -155,7 +158,7 @@ const Alerts = () => {
   return (
     <main className="container py-10">
       <SEO title={`${t('alerts.title')} | ${t('nav.tagline')}`} description="Crie alertas recorrentes" canonical="/alerts" />
-      <h1 className="text-3xl font-semibold mb-6">{t('alerts.title')}</h1>
+      <h1 className="text-3xl font-semibold mb-6" data-walkthrough="alerts-header">{t('alerts.title')}</h1>
 
       {agents.length === 0 ? (
         <Card className="shadow-sm">
@@ -169,7 +172,7 @@ const Alerts = () => {
       ) : (
         <div className="space-y-8">
           {/* Create Alert Form */}
-          <Card className="shadow-sm">
+          <Card className="shadow-sm" data-walkthrough="alerts-form">
             <CardHeader>
               <CardTitle>{t('alerts.newAlert')}</CardTitle>
             </CardHeader>
@@ -398,7 +401,7 @@ const Alerts = () => {
           </div>
 
           {/* Webhooks Section */}
-          <div className="space-y-4">
+          <div className="space-y-4" data-walkthrough="alerts-webhooks">
             <div className="flex items-center justify-between">
               <h2 className="text-xl font-semibold">{t('alerts.webhooks')}</h2>
               <Button variant="outline" onClick={() => setShowWebhookForm(!showWebhookForm)}>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,6 +15,8 @@ import { ArrowLeft, Layout, MoreVertical, Pencil, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
+import { usePageWalkthrough } from "@/contexts/WalkthroughContext";
+import { dashboardSteps } from "@/components/walkthrough/steps/dashboardSteps";
 
 interface DashboardData {
   id: string;
@@ -55,7 +57,8 @@ const Dashboard = () => {
   const { t } = useLanguage();
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
-  
+  usePageWalkthrough('dashboard', dashboardSteps);
+
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -215,7 +218,7 @@ const Dashboard = () => {
       
       <div className="w-full max-w-7xl mx-auto px-6 py-8">
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center justify-between mb-8" data-walkthrough="dash-header">
           <div className="flex items-center gap-4">
             <Button variant="ghost" size="icon" onClick={() => navigate('/')}>
               <ArrowLeft className="h-4 w-4" />
@@ -269,7 +272,7 @@ const Dashboard = () => {
             </Button>
           </Card>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-walkthrough="dash-charts-grid">
             {dashboard.dashboard_charts.map((chart) => (
               <Card key={chart.id} className="overflow-hidden">
                 <div className="relative">
@@ -284,7 +287,7 @@ const Dashboard = () => {
                       </div>
                     }
                   />
-                  <div className="absolute top-2 right-2">
+                  <div className="absolute top-2 right-2" data-walkthrough="dash-chart-actions">
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button variant="secondary" size="icon" className="h-8 w-8">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,8 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { usePageWalkthrough } from "@/contexts/WalkthroughContext";
+import { indexSteps } from "@/components/walkthrough/steps/indexSteps";
 import { useAuth } from "@/hooks/useAuth";
 import { dataClient } from "@/services/dataClient";
 import { BarChart3, Grid3x3, Layout, List, MoreVertical, Pencil, Plus } from "lucide-react";
@@ -37,6 +39,7 @@ const Index = () => {
   const { isAuthenticated, initializing, loginRequired } = useAuth();
   const { t } = useLanguage();
   const navigate = useNavigate();
+  usePageWalkthrough('index', indexSteps);
   const [agents, setAgents] = useState<Agent[]>([]);
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
   const [loading, setLoading] = useState(true);
@@ -196,10 +199,10 @@ const Index = () => {
       <SEO title={t('workspace.title')} description={t('workspace.description')} canonical="/" />
       
       <div className="w-full max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        <div className="flex items-center mb-8">
+        <div className="flex items-center mb-8" data-walkthrough="index-hero">
           <h1 className="text-2xl font-semibold">{t('workspace.title')}</h1>
 
-          <div className="flex items-center gap-2 ml-auto">
+          <div className="flex items-center gap-2 ml-auto" data-walkthrough="index-view-controls">
             <Button variant={viewMode === "grid" ? "secondary" : "ghost"} size="icon" onClick={() => setViewMode("grid")}>
               <Grid3x3 className="h-4 w-4" />
             </Button>
@@ -228,14 +231,14 @@ const Index = () => {
               </DropdownMenuContent>
             </DropdownMenu>
 
-            <Button onClick={handleCreateWorkspace}>
+            <Button onClick={handleCreateWorkspace} data-walkthrough="index-create-btn">
               <Plus className="h-4 w-4 mr-2" />
               {t('workspace.newWorkspace')}
             </Button>
           </div>
         </div>
 
-        {viewMode === "grid" ? <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4">
+        {viewMode === "grid" ? <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4" data-walkthrough="index-agents-grid">
             {/* Create new card */}
             <Card className="p-6 flex flex-col items-center justify-center cursor-pointer hover:bg-accent/50 transition-colors min-h-[200px]" onClick={handleCreateWorkspace}>
               <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center mb-3">
@@ -279,7 +282,7 @@ const Index = () => {
                   </p>
                 </div>
               </Card>)}
-          </div> : <div className="space-y-2">
+          </div> : <div className="space-y-2" data-walkthrough="index-agents-grid">
             {/* Create new list item */}
             <Card className="p-4 flex items-center gap-4 cursor-pointer hover:bg-accent/50 transition-colors" onClick={handleCreateWorkspace}>
               <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0">

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -39,6 +39,8 @@ import {
     SheetTrigger,
 } from "@/components/ui/sheet";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { usePageWalkthrough } from "@/contexts/WalkthroughContext";
+import { workspaceSteps } from "@/components/walkthrough/steps/workspaceSteps";
 import { useAuth } from "@/hooks/useAuth";
 import { dataClient } from "@/services/dataClient";
 import { BarChart3, Bot, ChevronRight, History, Layout, Link2, RotateCcw, Send, Table, Terminal, Upload, X } from "lucide-react";
@@ -242,6 +244,7 @@ interface QASessionRecord {
 export default function Workspace() {
   const { t } = useLanguage();
   const { user } = useAuth();
+  usePageWalkthrough('workspace', workspaceSteps);
   const stripFollowUpsFromAnswer = (answer: string, followUps?: string[]) => {
     if (!answer) return answer;
     if (!followUps || followUps.length === 0) return answer;
@@ -709,7 +712,7 @@ export default function Workspace() {
       
       <div className="flex-1 flex gap-4 overflow-hidden">
         {/* Sources Panel - Left */}
-        <div className="w-80 flex-shrink-0 bg-card border rounded-xl overflow-hidden flex flex-col">
+        <div className="w-80 flex-shrink-0 bg-card border rounded-xl overflow-hidden flex flex-col" data-walkthrough="ws-sources-panel">
           <SourcesPanel 
             agentId={id} 
             onAddSource={() => setAddSourceOpen(true)}
@@ -720,7 +723,7 @@ export default function Workspace() {
 
         {/* Chat Panel - Center */}
         <div className="flex-1 min-h-0 flex flex-col bg-card border rounded-xl overflow-hidden">
-          <div className="p-4 border-b flex items-center justify-between h-[57px]">
+          <div className="p-4 border-b flex items-center justify-between h-[57px]" data-walkthrough="ws-header">
             <h1 className="font-semibold">{t('workspace.chat')}</h1>
             
             <div className="flex items-center gap-2">
@@ -744,7 +747,7 @@ export default function Workspace() {
               </Button>
               <Sheet open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
                 <SheetTrigger asChild>
-                  <Button variant="outline" size="icon">
+                  <Button variant="outline" size="icon" data-walkthrough="ws-history-btn">
                     <History className="h-4 w-4" />
                   </Button>
                 </SheetTrigger>
@@ -825,7 +828,7 @@ export default function Workspace() {
             </div>
           </div>
 
-          <div className="flex-1 min-h-0 overflow-y-auto px-4 py-6">
+          <div className="flex-1 min-h-0 overflow-y-auto px-4 py-6" data-walkthrough="ws-chat-area">
             {availableColumns.length > 0 && messages.length === 0 && (
               <div className="mb-6">
                 <div className="flex items-center gap-2 mb-3">
@@ -1016,7 +1019,7 @@ export default function Workspace() {
                   ))}
                 </div>
               )}
-              <div className="flex gap-2">
+              <div className="flex gap-2" data-walkthrough="ws-chat-input">
                 <div className="flex-1 min-w-0 h-12 flex flex-wrap items-center gap-1.5 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 has-[:disabled]:opacity-50">
                   {questionSegments.map((seg, i) =>
                     seg.type === "text" ? (
@@ -1071,7 +1074,7 @@ export default function Workspace() {
         </div>
 
         {/* Studio Panel - Right */}
-        {!studioPanelCollapsed && <div className="w-80 flex-shrink-0 bg-card border rounded-xl overflow-hidden flex flex-col">
+        {!studioPanelCollapsed && <div className="w-80 flex-shrink-0 bg-card border rounded-xl overflow-hidden flex flex-col" data-walkthrough="ws-studio-panel">
             <StudioPanel
               collapsed={studioPanelCollapsed}
               onToggleCollapse={() => setStudioPanelCollapsed(!studioPanelCollapsed)}


### PR DESCRIPTION
## Summary
- Adds a complete per-page walkthrough/onboarding system that guides first-time users through each screen's functionality
- Spotlight overlay (box-shadow cutout), CSS arrows, step-by-step tooltips with progress dots, skip/prev/next navigation
- Keyboard support (Escape, ArrowRight, ArrowLeft)
- Shows only once per page (localStorage persistence), with global skip option
- Full i18n support (EN/PT/ES) integrated with existing LanguageContext
- Covers 6 pages: Index, Workspace, Dashboard, AgentBriefing, Account, Alerts

## New files
- `src/contexts/WalkthroughContext.tsx` — Provider + hooks
- `src/components/walkthrough/` — Overlay, Tooltip, Arrow, types, and step definitions per page

## Modified files
- `src/App.tsx` — WalkthroughProvider added to provider stack
- `src/contexts/LanguageContext.tsx` — ~80 translation keys per language
- 6 page files + SourcesPanel — data-walkthrough attributes and hook calls

## Test plan
- [ ] Open each page as a first-time user (clear dt_walkthrough from localStorage) — walkthrough should appear
- [ ] Click Next through all steps — spotlight should move to each target element
- [ ] Click Skip tutorial — walkthrough should dismiss and not reappear
- [ ] Reload page — walkthrough should NOT reappear (persisted in localStorage)
- [ ] Clear localStorage, reload — walkthrough should reappear
- [ ] Switch languages during walkthrough — text should update
- [ ] Press Escape — should dismiss walkthrough
- [ ] Verify build passes: npm run typecheck and npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)