### PR TITLE
fix: improve chart tooltip styling and simplify remove-image buttons

### DIFF
--- a/src/components/ChartRenderer.tsx
+++ b/src/components/ChartRenderer.tsx
@@ -43,6 +43,18 @@ const PALETTE = [
   "#06b6d4",
 ];
 
+const tooltipStyle: React.CSSProperties = {
+  backgroundColor: "hsl(var(--popover))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: "8px",
+  color: "#fff",
+  fontSize: "12px",
+  boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+};
+
+const tooltipLabelStyle: React.CSSProperties = { color: "#fff" };
+const tooltipItemStyle: React.CSSProperties = { color: "#fff" };
+
 interface ChartRendererProps {
   spec: ChartSpec;
   className?: string;
@@ -90,7 +102,7 @@ export function ChartRenderer({ spec, className }: ChartRendererProps) {
             <Cell key={idx} fill={PALETTE[idx % PALETTE.length]} />
           ))}
         </Pie>
-        <Tooltip formatter={(value: number) => value.toLocaleString()} />
+        <Tooltip formatter={(value: number) => value.toLocaleString()} contentStyle={tooltipStyle} labelStyle={tooltipLabelStyle} itemStyle={tooltipItemStyle} />
         {renderLegend && <Legend />}
       </PieChart>
     );
@@ -125,7 +137,7 @@ export function ChartRenderer({ spec, className }: ChartRendererProps) {
               : undefined
           }
         />
-        <Tooltip formatter={(value: number) => value.toLocaleString()} />
+        <Tooltip formatter={(value: number) => value.toLocaleString()} cursor={{ stroke: "hsl(var(--border))" }} contentStyle={tooltipStyle} labelStyle={tooltipLabelStyle} itemStyle={tooltipItemStyle} />
         {renderLegend && <Legend />}
         {spec.series.map((s, idx) => (
           <Line
@@ -158,7 +170,7 @@ export function ChartRenderer({ spec, className }: ChartRendererProps) {
           width={120}
           tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 11 }}
         />
-        <Tooltip formatter={(value: number) => value.toLocaleString()} />
+        <Tooltip formatter={(value: number) => value.toLocaleString()} cursor={{ fill: "transparent" }} contentStyle={tooltipStyle} labelStyle={tooltipLabelStyle} itemStyle={tooltipItemStyle} />
         {renderLegend && <Legend />}
         {spec.series.map((s, idx) =>
           multiSeries ? (
@@ -205,7 +217,7 @@ export function ChartRenderer({ spec, className }: ChartRendererProps) {
               : undefined
           }
         />
-        <Tooltip formatter={(value: number) => value.toLocaleString()} />
+        <Tooltip formatter={(value: number) => value.toLocaleString()} cursor={{ fill: "transparent" }} contentStyle={tooltipStyle} labelStyle={tooltipLabelStyle} itemStyle={tooltipItemStyle} />
         {renderLegend && <Legend />}
         {spec.series.map((s, idx) =>
           multiSeries ? (

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -144,13 +144,13 @@ const ChartImage = ({ imageUrl, qaSessionId, t, onRemoveImage }: { imageUrl: str
           <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
             {onRemoveImage && (
               <Button
-                size="sm"
-                variant="destructive"
+                variant="ghost"
+                size="icon"
                 onClick={onRemoveImage}
-                className="bg-destructive/90 text-destructive-foreground hover:bg-destructive border border-destructive shadow-sm"
+                className="h-6 w-6"
                 title={t('workspace.removeImage') || 'Remover imagem'}
               >
-                <X className="h-4 w-4" />
+                <X className="h-4 w-4 text-destructive" />
               </Button>
             )}
             {qaSessionId && (
@@ -965,13 +965,13 @@ export default function Workspace() {
                               {message.role === "assistant" && (
                                 <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
                                   <Button
-                                    size="sm"
-                                    variant="destructive"
+                                    variant="ghost"
+                                    size="icon"
                                     onClick={() => handleRemoveImageFromMessage(index)}
-                                    className="bg-destructive/90 text-destructive-foreground hover:bg-destructive border border-destructive shadow-sm"
+                                    className="h-6 w-6"
                                     title={t('workspace.removeImage') || 'Remover gráfico'}
                                   >
-                                    <X className="h-4 w-4" />
+                                    <X className="h-4 w-4 text-destructive" />
                                   </Button>
                                 </div>
                               )}


### PR DESCRIPTION
## Summary
- Style chart tooltips with themed background, border, rounded corners, and shadow for better dark-mode readability
- Change remove-image buttons from `destructive` variant to `ghost`/`icon` for a cleaner, less aggressive UI

## Test plan
- [ ] Open a workspace with chart results and hover over data points — tooltip should have dark background with white text
- [ ] Hover over chart images and verify the remove button appears as a subtle ghost icon instead of a red destructive button

🤖 Generated with [Claude Code](https://claude.com/claude-code)