### PR TITLE
feat: AI-assisted Medallion Architecture (Bronze/Silver/Gold layers)

### DIFF
--- a/backend/alembic/versions/20260407120000_add_medallion_tables.py
+++ b/backend/alembic/versions/20260407120000_add_medallion_tables.py
@@ -1,0 +1,66 @@
+"""Add medallion architecture tables (MedallionLayer, MedallionBuildLog).
+
+Revision ID: 20260407120000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20260407120000"
+down_revision: Union[str, None] = "20260319120000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    tables = inspector.get_table_names()
+
+    if "medallion_layers" not in tables:
+        op.create_table(
+            "medallion_layers",
+            sa.Column("id", sa.String(36), primary_key=True),
+            sa.Column("user_id", sa.String(36), sa.ForeignKey("users.id"), nullable=False),
+            sa.Column("source_id", sa.String(36), sa.ForeignKey("sources.id"), nullable=False, index=True),
+            sa.Column("agent_id", sa.String(36), nullable=False),
+            sa.Column("layer", sa.String(10), nullable=False),
+            sa.Column("table_name", sa.String(255), nullable=False),
+            sa.Column("status", sa.String(20), nullable=False, server_default="pending"),
+            sa.Column("schema_config", sa.JSON, nullable=False, server_default="{}"),
+            sa.Column("ddl_sql", sa.Text, nullable=False, server_default=""),
+            sa.Column("transform_sql", sa.Text, nullable=True),
+            sa.Column("row_count", sa.Integer, nullable=True),
+            sa.Column("error_message", sa.Text, nullable=True),
+            sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime, server_default=sa.func.now()),
+        )
+
+    if "medallion_build_logs" not in tables:
+        op.create_table(
+            "medallion_build_logs",
+            sa.Column("id", sa.String(36), primary_key=True),
+            sa.Column(
+                "layer_id",
+                sa.String(36),
+                sa.ForeignKey("medallion_layers.id", ondelete="SET NULL"),
+                nullable=True,
+                index=True,
+            ),
+            sa.Column("source_id", sa.String(36), nullable=False, index=True),
+            sa.Column("user_id", sa.String(36), nullable=False),
+            sa.Column("action", sa.String(30), nullable=False),
+            sa.Column("layer", sa.String(10), nullable=False),
+            sa.Column("input_feedback", sa.Text, nullable=True),
+            sa.Column("suggestion", sa.JSON, nullable=True),
+            sa.Column("applied_config", sa.JSON, nullable=True),
+            sa.Column("llm_usage", sa.JSON, nullable=True),
+            sa.Column("error_message", sa.Text, nullable=True),
+            sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("medallion_build_logs")
+    op.drop_table("medallion_layers")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.routers import api_keys_router, public_api_router, whatsapp_router, aud
 from app.routers import dbt_router, github_router, slack_router, mongodb_router, snowflake_router, notion_router, excel_online_router, s3_router, rest_api_router, jira_router, stripe_router, pipedrive_router
 from app.routers import template_router
 from app.routers import hubspot_router
+from app.routers import medallion_router
 from app.routers import salesforce_router
 from app.routers import ga4_router
 from app.routers import intercom_router
@@ -256,6 +257,7 @@ app.include_router(intercom_router.router, prefix=prefix)
 app.include_router(github_analytics_router.router, prefix=prefix)
 app.include_router(shopify_router.router, prefix=prefix)
 app.include_router(pipedrive_router.router, prefix=prefix)
+app.include_router(medallion_router.router, prefix=prefix)
 
 
 @app.get(prefix + "/config")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -437,3 +437,45 @@ class ApiKey(Base):
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
+
+# ---------------------------------------------------------------------------
+# Medallion Architecture (Bronze / Silver / Gold layers)
+# ---------------------------------------------------------------------------
+
+class MedallionLayer(Base):
+    """One row per layer per source. Bronze and silver get one each; gold can have multiple."""
+    __tablename__ = "medallion_layers"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"))
+    source_id: Mapped[str] = mapped_column(String(36), ForeignKey("sources.id"), index=True)
+    agent_id: Mapped[str] = mapped_column(String(36))
+    layer: Mapped[str] = mapped_column(String(10))  # bronze | silver | gold
+    table_name: Mapped[str] = mapped_column(String(255))
+    status: Mapped[str] = mapped_column(String(20), default="pending")  # pending | ready | error
+    schema_config: Mapped[dict] = mapped_column(JSON, default=dict)
+    ddl_sql: Mapped[str] = mapped_column(Text, default="")
+    transform_sql: Mapped[str | None] = mapped_column(Text, nullable=True)
+    row_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class MedallionBuildLog(Base):
+    """Audit trail: every AI suggestion, redo, and apply action is logged."""
+    __tablename__ = "medallion_build_logs"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    layer_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("medallion_layers.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    source_id: Mapped[str] = mapped_column(String(36), index=True)
+    user_id: Mapped[str] = mapped_column(String(36))
+    action: Mapped[str] = mapped_column(String(30))  # suggest | apply | redo | error
+    layer: Mapped[str] = mapped_column(String(10))  # bronze | silver | gold
+    input_feedback: Mapped[str | None] = mapped_column(Text, nullable=True)
+    suggestion: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    applied_config: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    llm_usage: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+

--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -202,6 +202,8 @@ async def dispatch_question(
             llm_overrides=llm_overrides,
             history=history,
             channel=channel,
+            source_id=source.id,
+            user_id=user.id,
         )
     elif source.type == "sqlite":
         meta = source.metadata_ or {}

--- a/backend/app/routers/medallion_router.py
+++ b/backend/app/routers/medallion_router.py
@@ -1,0 +1,263 @@
+"""Medallion Architecture API — Bronze / Silver / Gold layer management."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import require_user
+from app.config import get_settings
+from app.database import get_db
+from app.models import (
+    User, Source, Agent, MedallionLayer, MedallionBuildLog,
+    LlmConfig, LlmSettings,
+)
+from app.schemas import (
+    BronzeGenerateRequest, SilverSuggestRequest, SilverApplyRequest,
+    GoldSuggestRequest, GoldApplyRequest,
+)
+from app.services import medallion_service as svc
+
+router = APIRouter(prefix="/medallion", tags=["medallion"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _get_source(source_id: str, user_id: str, db: AsyncSession) -> Source:
+    result = await db.execute(
+        select(Source).where(Source.id == source_id, Source.user_id == user_id)
+    )
+    source = result.scalar_one_or_none()
+    if not source:
+        raise HTTPException(404, "Source not found")
+    return source
+
+
+async def _resolve_llm_overrides(agent_id: str, user_id: str, db: AsyncSession) -> dict | None:
+    """Load LLM config for the agent's user, following the same logic as ask.py."""
+    from app.routers.ask import _llm_config_to_overrides
+
+    # Try agent-specific config
+    result = await db.execute(select(Agent).where(Agent.id == agent_id))
+    agent = result.scalar_one_or_none()
+    if agent and agent.llm_config_id:
+        cfg_result = await db.execute(
+            select(LlmConfig).where(LlmConfig.id == agent.llm_config_id)
+        )
+        cfg = cfg_result.scalar_one_or_none()
+        if cfg:
+            return _llm_config_to_overrides(cfg)
+
+    # Fallback to user default LlmSettings
+    settings_result = await db.execute(
+        select(LlmSettings).where(LlmSettings.user_id == user_id)
+    )
+    settings = settings_result.scalar_one_or_none()
+    return _llm_config_to_overrides(settings)
+
+
+def _layer_out(d: dict) -> dict:
+    """Passthrough — service already returns camelCase dict."""
+    return d
+
+
+def _log_out(d: dict) -> dict:
+    return d
+
+
+# ---------------------------------------------------------------------------
+# List layers & logs
+# ---------------------------------------------------------------------------
+
+@router.get("/sources/{source_id}/layers")
+async def list_layers(
+    source_id: str,
+    user: User = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await _get_source(source_id, user.id, db)
+    result = await db.execute(
+        select(MedallionLayer)
+        .where(MedallionLayer.source_id == source_id, MedallionLayer.user_id == user.id)
+        .order_by(MedallionLayer.created_at)
+    )
+    layers = result.scalars().all()
+    return [svc._layer_to_dict(l) for l in layers]
+
+
+@router.get("/sources/{source_id}/logs")
+async def list_logs(
+    source_id: str,
+    user: User = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await _get_source(source_id, user.id, db)
+    result = await db.execute(
+        select(MedallionBuildLog)
+        .where(MedallionBuildLog.source_id == source_id, MedallionBuildLog.user_id == user.id)
+        .order_by(MedallionBuildLog.created_at.desc())
+    )
+    logs = result.scalars().all()
+    return [svc._log_to_dict(entry) for entry in logs]
+
+
+@router.get("/layers/{layer_id}")
+async def get_layer(
+    layer_id: str,
+    user: User = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(MedallionLayer).where(
+            MedallionLayer.id == layer_id, MedallionLayer.user_id == user.id
+        )
+    )
+    layer = result.scalar_one_or_none()
+    if not layer:
+        raise HTTPException(404, "Layer not found")
+    return svc._layer_to_dict(layer)
+
+
+# ---------------------------------------------------------------------------
+# Bronze
+# ---------------------------------------------------------------------------
+
+@router.post("/bronze/generate")
+async def generate_bronze(
+    body: BronzeGenerateRequest,
+    user: User = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    source = await _get_source(body.sourceId, user.id, db)
+    settings = get_settings()
+    try:
+        layer = await svc.generate_bronze(
+            source, user.id, body.agentId, settings.data_files_dir, db
+        )
+        return layer
+    except Exception as e:
+        raise HTTPException(400, str(e))
+
+
+# ---------------------------------------------------------------------------
+# Silver — suggest & apply
+# ---------------------------------------------------------------------------
+
+@router.post("/silver/suggest")
+async def suggest_silver(
+    body: SilverSuggestRequest,
+    user: User = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    source = await _get_source(body.sourceId, user.id, db)
+    settings = get_settings()
+    llm_overrides = await _resolve_llm_overrides(body.agentId, user.id, db)
+    try:
+        result = await svc.suggest_silver(
+            source, user.id, body.agentId, settings.data_files_dir, db,
+            llm_overrides=llm_overrides,
+            feedback=body.feedback,
+        )
+        return result
+    except Exception as e:
+        raise HTTPException(400, str(e))
+
+
+@router.post("/silver/apply")
+async def apply_silver(
+    body: SilverApplyRequest,
+    user: User = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    source = await _get_source(body.sourceId, user.id, db)
+    settings = get_settings()
+    try:
+        layer = await svc.apply_silver(
+            source, user.id, body.agentId, settings.data_files_dir, db,
+            build_log_id=body.buildLogId,
+            config=body.config,
+        )
+        return layer
+    except Exception as e:
+        raise HTTPException(400, str(e))
+
+
+# ---------------------------------------------------------------------------
+# Gold — suggest & apply
+# ---------------------------------------------------------------------------
+
+@router.post("/gold/suggest")
+async def suggest_gold(
+    body: GoldSuggestRequest,
+    user: User = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    source = await _get_source(body.sourceId, user.id, db)
+    settings = get_settings()
+    llm_overrides = await _resolve_llm_overrides(body.agentId, user.id, db)
+    try:
+        result = await svc.suggest_gold(
+            source, user.id, body.agentId, settings.data_files_dir, db,
+            llm_overrides=llm_overrides,
+            feedback=body.feedback,
+        )
+        return result
+    except Exception as e:
+        raise HTTPException(400, str(e))
+
+
+@router.post("/gold/apply")
+async def apply_gold(
+    body: GoldApplyRequest,
+    user: User = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    source = await _get_source(body.sourceId, user.id, db)
+    settings = get_settings()
+    try:
+        layers = await svc.apply_gold(
+            source, user.id, body.agentId, settings.data_files_dir, db,
+            build_log_id=body.buildLogId,
+            selected_tables=body.selectedTables,
+        )
+        return {"layers": layers, "totalRows": sum(l.get("rowCount", 0) or 0 for l in layers)}
+    except Exception as e:
+        raise HTTPException(400, str(e))
+
+
+# ---------------------------------------------------------------------------
+# Delete layer
+# ---------------------------------------------------------------------------
+
+@router.delete("/layers/{layer_id}")
+async def delete_layer(
+    layer_id: str,
+    user: User = Depends(require_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(MedallionLayer).where(
+            MedallionLayer.id == layer_id, MedallionLayer.user_id == user.id
+        )
+    )
+    layer = result.scalar_one_or_none()
+    if not layer:
+        raise HTTPException(404, "Layer not found")
+
+    # Cascade: if deleting bronze, also delete silver+gold; if silver, delete gold
+    if layer.layer in ("bronze", "silver"):
+        cascade_layers = ["gold"] if layer.layer == "silver" else ["silver", "gold"]
+        cascade_result = await db.execute(
+            select(MedallionLayer).where(
+                MedallionLayer.source_id == layer.source_id,
+                MedallionLayer.layer.in_(cascade_layers),
+            )
+        )
+        for cl in cascade_result.scalars().all():
+            await db.delete(cl)
+
+    await db.delete(layer)
+    await db.flush()
+    return {"ok": True}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -126,3 +126,80 @@ class PublicAskRequest(BaseModel):
     source_ids: Optional[list[str]] = None   # subset of agent sources; None = use all
     sql_mode: Optional[bool] = None          # override agent default; None = use agent setting
     session_id: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Medallion Architecture
+# ---------------------------------------------------------------------------
+
+class BronzeGenerateRequest(BaseModel):
+    sourceId: str
+    agentId: str
+
+
+class SilverSuggestRequest(BaseModel):
+    sourceId: str
+    agentId: str
+    feedback: Optional[str] = None  # when present, acts as "redo with direction"
+
+
+class SilverApplyRequest(BaseModel):
+    sourceId: str
+    agentId: str
+    buildLogId: str
+    config: dict  # user-edited silver suggestion
+
+
+class GoldSuggestRequest(BaseModel):
+    sourceId: str
+    agentId: str
+    feedback: Optional[str] = None
+
+
+class GoldApplyRequest(BaseModel):
+    sourceId: str
+    agentId: str
+    buildLogId: str
+    selectedTables: list[dict]  # list of gold aggregate configs to materialize
+
+
+class MedallionLayerOut(BaseModel):
+    id: str
+    sourceId: str
+    agentId: str
+    layer: str
+    tableName: str
+    status: str
+    schemaConfig: dict = {}
+    ddlSql: str = ""
+    transformSql: Optional[str] = None
+    rowCount: Optional[int] = None
+    errorMessage: Optional[str] = None
+    createdAt: Optional[str] = None
+    updatedAt: Optional[str] = None
+
+
+class MedallionBuildLogOut(BaseModel):
+    id: str
+    layerId: Optional[str] = None
+    action: str
+    layer: str
+    inputFeedback: Optional[str] = None
+    suggestion: Optional[dict] = None
+    appliedConfig: Optional[dict] = None
+    llmUsage: Optional[dict] = None
+    errorMessage: Optional[str] = None
+    createdAt: Optional[str] = None
+
+
+class SilverSuggestResponse(BaseModel):
+    suggestion: dict
+    ddlPreview: str
+    transformPreview: str
+    buildLogId: str
+
+
+class GoldSuggestResponse(BaseModel):
+    suggestions: list[dict]
+    ddlPreviews: list[str] = []
+    buildLogId: str

--- a/backend/app/scripts/ask_csv.py
+++ b/backend/app/scripts/ask_csv.py
@@ -33,6 +33,8 @@ async def ask_csv(
     llm_overrides: dict | None = None,
     history: list[dict] | None = None,
     channel: str = "workspace",
+    source_id: str | None = None,
+    user_id: str | None = None,
 ) -> dict[str, Any]:
     """
     file_path: path relative to data_files (e.g. user_id/timestamp.csv).
@@ -43,24 +45,68 @@ async def ask_csv(
     if not full_path.exists():
         raise FileNotFoundError(f"File not found: {file_path}")
 
-    # Load full file for SQL execution (CSV or XLSX)
-    df_full = _load_full_dataframe(full_path)
-    columns = list(df_full.columns)
-    full_row_count = len(df_full)
-    preview = df_full.head(10).to_dict(orient="records")
-    schema_text = _format_schema(columns, preview)
-    sample_json = str(preview[:5])
-    sample_profile = _build_sample_profile(df_full.head(1000))
-    profile_text = _format_profile(sample_profile)
+    # ── Medallion routing: prefer Silver/Gold tables when available ──
+    medallion_conn = None
+    medallion_tables: dict[str, list[tuple[str, str]]] = {}
+    if source_id and user_id:
+        try:
+            from app.services.medallion_service import get_medallion_connection, list_medallion_tables
+            medallion_conn = get_medallion_connection(data_files_dir, user_id, source_id)
+            if medallion_conn:
+                medallion_tables = list_medallion_tables(medallion_conn)
+        except Exception:
+            medallion_conn = None
 
-    # Create in-memory SQLite with table "data" for SQL execution
-    conn = sqlite3.connect(":memory:")
-    df_full.to_sql("data", conn, index=False, if_exists="replace")
+    # If we have silver or gold tables, use the medallion DB instead of raw CSV
+    silver_tables = {k: v for k, v in medallion_tables.items() if k.startswith("silver_")}
+    gold_tables = {k: v for k, v in medallion_tables.items() if k.startswith("gold_")}
+    use_medallion = bool(silver_tables or gold_tables)
 
-    schema_for_sql = (
-        f"Table 'data' with columns: {', '.join(columns)}. "
-        "Use SELECT ... FROM data. Quote column names with double quotes if they have spaces or special chars (e.g. \"Release Year\")."
-    )
+    if use_medallion and medallion_conn:
+        conn = medallion_conn
+        # Build schema from all available medallion tables
+        all_tables = {**silver_tables, **gold_tables}
+        table_descs = []
+        all_columns_flat: list[str] = []
+        for tname, cols in all_tables.items():
+            col_names = [c[0] for c in cols]
+            all_columns_flat.extend(col_names)
+            table_descs.append(f"Table '{tname}' with columns: {', '.join(f'{c[0]} ({c[1]})' for c in cols)}")
+        columns = list(set(all_columns_flat))
+
+        # Load sample from first silver table for profile
+        first_table = list(silver_tables.keys())[0] if silver_tables else list(gold_tables.keys())[0]
+        df_sample = pd.read_sql_query(f'SELECT * FROM "{first_table}" LIMIT 1000', conn)
+        full_row_count = pd.read_sql_query(f'SELECT COUNT(*) as c FROM "{first_table}"', conn).iloc[0]["c"]
+        preview = df_sample.head(10).to_dict(orient="records")
+        schema_text = _format_schema(list(df_sample.columns), preview)
+        sample_json = str(preview[:5])
+        sample_profile = _build_sample_profile(df_sample)
+        profile_text = _format_profile(sample_profile)
+
+        schema_for_sql = "\n".join(table_descs) + (
+            "\nUse SELECT ... FROM <table_name>. "
+            "Quote column names with double quotes if they have spaces or special chars."
+        )
+    else:
+        # Load full file for SQL execution (CSV or XLSX) — original behavior
+        df_full = _load_full_dataframe(full_path)
+        columns = list(df_full.columns)
+        full_row_count = len(df_full)
+        preview = df_full.head(10).to_dict(orient="records")
+        schema_text = _format_schema(columns, preview)
+        sample_json = str(preview[:5])
+        sample_profile = _build_sample_profile(df_full.head(1000))
+        profile_text = _format_profile(sample_profile)
+
+        # Create in-memory SQLite with table "data" for SQL execution
+        conn = sqlite3.connect(":memory:")
+        df_full.to_sql("data", conn, index=False, if_exists="replace")
+
+        schema_for_sql = (
+            f"Table 'data' with columns: {', '.join(columns)}. "
+            "Use SELECT ... FROM data. Quote column names with double quotes if they have spaces or special chars (e.g. \"Release Year\")."
+        )
 
     system = (
         "You are an assistant that answers questions about tabular data (CSV/spreadsheet). "

--- a/backend/app/services/medallion_service.py
+++ b/backend/app/services/medallion_service.py
@@ -1,0 +1,735 @@
+"""
+Medallion Architecture service — Bronze / Silver / Gold layer generation.
+
+Each source gets a persistent SQLite file at
+  {data_files_dir}/{user_id}/medallion_{source_id}.db
+The platform app DB (async SQLAlchemy) stores only metadata
+(MedallionLayer, MedallionBuildLog); the medallion DB holds actual row data.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import MedallionLayer, MedallionBuildLog, Source
+from app.llm.client import chat_completion
+from app.scripts.ask_csv import _load_full_dataframe, _build_sample_profile, _format_profile
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _short_id(source_id: str) -> str:
+    """First 8 chars of the source UUID (safe for table names)."""
+    return source_id.replace("-", "")[:8]
+
+
+def _medallion_db_path(data_files_dir: str, user_id: str, source_id: str) -> Path:
+    return Path(data_files_dir) / user_id / f"medallion_{source_id}.db"
+
+
+def _get_medallion_conn(data_files_dir: str, user_id: str, source_id: str) -> sqlite3.Connection:
+    path = _medallion_db_path(data_files_dir, user_id, source_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(str(path))
+
+
+def _row_hash(row: dict) -> str:
+    raw = json.dumps(row, sort_keys=True, default=str)
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+def _layer_to_dict(layer: MedallionLayer) -> dict:
+    return {
+        "id": layer.id,
+        "sourceId": layer.source_id,
+        "agentId": layer.agent_id,
+        "layer": layer.layer,
+        "tableName": layer.table_name,
+        "status": layer.status,
+        "schemaConfig": layer.schema_config or {},
+        "ddlSql": layer.ddl_sql or "",
+        "transformSql": layer.transform_sql,
+        "rowCount": layer.row_count,
+        "errorMessage": layer.error_message,
+        "createdAt": layer.created_at.isoformat() if layer.created_at else None,
+        "updatedAt": layer.updated_at.isoformat() if layer.updated_at else None,
+    }
+
+
+def _log_to_dict(entry: MedallionBuildLog) -> dict:
+    return {
+        "id": entry.id,
+        "layerId": entry.layer_id,
+        "action": entry.action,
+        "layer": entry.layer,
+        "inputFeedback": entry.input_feedback,
+        "suggestion": entry.suggestion,
+        "appliedConfig": entry.applied_config,
+        "llmUsage": entry.llm_usage,
+        "errorMessage": entry.error_message,
+        "createdAt": entry.created_at.isoformat() if entry.created_at else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bronze
+# ---------------------------------------------------------------------------
+
+async def generate_bronze(
+    source: Source,
+    user_id: str,
+    agent_id: str,
+    data_files_dir: str,
+    db: AsyncSession,
+) -> dict:
+    """Create bronze table from raw source file. Returns layer dict."""
+    meta = source.metadata_ or {}
+    file_path_str = meta.get("file_path", "")
+    if not file_path_str:
+        raise ValueError("Source has no file_path in metadata")
+
+    full_path = Path(data_files_dir) / file_path_str
+    if not full_path.exists():
+        raise FileNotFoundError(f"Source file not found: {full_path}")
+
+    df = _load_full_dataframe(full_path)
+    sid = _short_id(source.id)
+    table_name = f"bronze_{sid}"
+
+    # Build DDL: all columns as TEXT + metadata columns
+    col_defs = [
+        "_loaded_at TEXT",
+        "_source_file TEXT",
+        "_row_hash TEXT",
+    ]
+    for col in df.columns:
+        safe_col = str(col).replace('"', '""')
+        col_defs.append(f'"{safe_col}" TEXT')
+
+    ddl = f'CREATE TABLE IF NOT EXISTS "{table_name}" (\n  ' + ",\n  ".join(col_defs) + "\n);"
+
+    # Insert data
+    conn = _get_medallion_conn(data_files_dir, user_id, source.id)
+    try:
+        conn.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+        conn.execute(ddl)
+
+        now_str = datetime.utcnow().isoformat()
+        source_file = Path(file_path_str).name
+
+        placeholders = ", ".join(["?"] * (len(df.columns) + 3))
+        insert_sql = f'INSERT INTO "{table_name}" VALUES ({placeholders})'
+
+        rows_to_insert = []
+        for _, row in df.iterrows():
+            row_dict = row.to_dict()
+            rh = _row_hash(row_dict)
+            values = [now_str, source_file, rh] + [
+                str(v) if pd.notna(v) else None for v in row.values
+            ]
+            rows_to_insert.append(values)
+
+        conn.executemany(insert_sql, rows_to_insert)
+        conn.commit()
+        row_count = len(rows_to_insert)
+    finally:
+        conn.close()
+
+    # Save layer metadata in app DB
+    schema_config = {
+        "columns": list(df.columns),
+        "metadata_columns": ["_loaded_at", "_source_file", "_row_hash"],
+    }
+
+    layer = MedallionLayer(
+        id=_uid(),
+        user_id=user_id,
+        source_id=source.id,
+        agent_id=agent_id,
+        layer="bronze",
+        table_name=table_name,
+        status="ready",
+        schema_config=schema_config,
+        ddl_sql=ddl,
+        row_count=row_count,
+    )
+    db.add(layer)
+
+    build_log = MedallionBuildLog(
+        id=_uid(),
+        layer_id=layer.id,
+        source_id=source.id,
+        user_id=user_id,
+        action="apply",
+        layer="bronze",
+        applied_config=schema_config,
+    )
+    db.add(build_log)
+    await db.flush()
+
+    return _layer_to_dict(layer)
+
+
+# ---------------------------------------------------------------------------
+# Silver — Suggest
+# ---------------------------------------------------------------------------
+
+_SILVER_SYSTEM_PROMPT = """\
+You are a data engineer. Analyze this raw data profile from a Bronze (raw staging) layer \
+and suggest a Silver (cleaned) schema.
+
+For each column, suggest:
+1. **target_type**: Appropriate SQL data type (INTEGER, REAL, TEXT, DATE, TIMESTAMP, BOOLEAN)
+2. **cast_expression**: SQL expression to transform from TEXT (e.g., `CAST(col AS INTEGER)`, `LOWER(TRIM(col))`)
+3. **null_strategy**: One of DROP_ROW, FILL_DEFAULT, FILL_ZERO, KEEP_NULL
+4. **null_default**: Default value when null_strategy is FILL_DEFAULT (optional)
+5. **silver_name**: Cleaned snake_case column name
+
+Also suggest deduplication if you detect a primary key candidate:
+- **dedup_key**: list of column names forming the unique key
+- **dedup_order_by**: column to ORDER BY DESC for keeping latest
+
+Return ONLY valid JSON in this exact format:
+{
+  "columns": [
+    {
+      "source_column": "original_name",
+      "silver_name": "clean_name",
+      "target_type": "INTEGER",
+      "cast_expression": "CAST(\\"original_name\\" AS INTEGER)",
+      "null_strategy": "KEEP_NULL",
+      "null_default": null
+    }
+  ],
+  "dedup_key": [],
+  "dedup_order_by": null,
+  "explanation": "Brief explanation of your choices"
+}
+"""
+
+
+async def suggest_silver(
+    source: Source,
+    user_id: str,
+    agent_id: str,
+    data_files_dir: str,
+    db: AsyncSession,
+    llm_overrides: dict | None = None,
+    feedback: str | None = None,
+) -> dict:
+    """Use LLM to suggest silver schema. Returns {suggestion, ddlPreview, transformPreview, buildLogId}."""
+    # Get bronze layer
+    result = await db.execute(
+        select(MedallionLayer).where(
+            MedallionLayer.source_id == source.id,
+            MedallionLayer.layer == "bronze",
+            MedallionLayer.status == "ready",
+        )
+    )
+    bronze = result.scalar_one_or_none()
+    if not bronze:
+        raise ValueError("Bronze layer must be built first")
+
+    # Load sample data from medallion DB for profiling
+    conn = _get_medallion_conn(data_files_dir, user_id, source.id)
+    try:
+        df = pd.read_sql_query(
+            f'SELECT * FROM "{bronze.table_name}" LIMIT 1000',
+            conn,
+        )
+    finally:
+        conn.close()
+
+    # Drop metadata columns for profiling
+    data_cols = [c for c in df.columns if not c.startswith("_")]
+    df_data = df[data_cols]
+
+    profile = _build_sample_profile(df_data)
+    profile_text = _format_profile(profile)
+
+    user_msg = f"""Bronze table: {bronze.table_name}
+Columns (all stored as TEXT): {', '.join(data_cols)}
+Row count: {bronze.row_count}
+
+Data profile:
+{profile_text}
+
+Sample rows (first 3):
+{df_data.head(3).to_string(index=False)}
+"""
+
+    if feedback:
+        user_msg += f"\n\nUser feedback on previous suggestion — please adjust accordingly:\n{feedback}"
+
+    messages = [
+        {"role": "system", "content": _SILVER_SYSTEM_PROMPT},
+        {"role": "user", "content": user_msg},
+    ]
+
+    raw_content, usage, _trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    # Parse JSON from LLM response
+    suggestion = _parse_json_response(raw_content)
+    sid = _short_id(source.id)
+
+    # Generate preview SQL
+    ddl_preview = _build_silver_ddl(suggestion, sid)
+    transform_preview = _build_silver_transform(suggestion, bronze.table_name, f"silver_{sid}")
+
+    # Log
+    action = "redo" if feedback else "suggest"
+    build_log = MedallionBuildLog(
+        id=_uid(),
+        source_id=source.id,
+        user_id=user_id,
+        action=action,
+        layer="silver",
+        input_feedback=feedback,
+        suggestion=suggestion,
+        llm_usage=usage,
+    )
+    db.add(build_log)
+    await db.flush()
+
+    return {
+        "suggestion": suggestion,
+        "ddlPreview": ddl_preview,
+        "transformPreview": transform_preview,
+        "buildLogId": build_log.id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Silver — Apply
+# ---------------------------------------------------------------------------
+
+async def apply_silver(
+    source: Source,
+    user_id: str,
+    agent_id: str,
+    data_files_dir: str,
+    db: AsyncSession,
+    build_log_id: str,
+    config: dict,
+) -> dict:
+    """Apply user-edited silver config. Returns layer dict."""
+    # Get bronze
+    result = await db.execute(
+        select(MedallionLayer).where(
+            MedallionLayer.source_id == source.id,
+            MedallionLayer.layer == "bronze",
+            MedallionLayer.status == "ready",
+        )
+    )
+    bronze = result.scalar_one_or_none()
+    if not bronze:
+        raise ValueError("Bronze layer must be built first")
+
+    sid = _short_id(source.id)
+    silver_table = f"silver_{sid}"
+    ddl = _build_silver_ddl(config, sid)
+    transform = _build_silver_transform(config, bronze.table_name, silver_table)
+
+    # Execute on medallion DB
+    conn = _get_medallion_conn(data_files_dir, user_id, source.id)
+    try:
+        conn.execute(f'DROP TABLE IF EXISTS "{silver_table}"')
+        conn.execute(ddl)
+        conn.execute(transform)
+        conn.commit()
+        cursor = conn.execute(f'SELECT COUNT(*) FROM "{silver_table}"')
+        row_count = cursor.fetchone()[0]
+    except Exception as e:
+        conn.rollback()
+        # Log error
+        err_log = MedallionBuildLog(
+            id=_uid(), source_id=source.id, user_id=user_id,
+            action="error", layer="silver", error_message=str(e),
+        )
+        db.add(err_log)
+        await db.flush()
+        raise
+    finally:
+        conn.close()
+
+    # Delete existing silver layer if any
+    old = await db.execute(
+        select(MedallionLayer).where(
+            MedallionLayer.source_id == source.id,
+            MedallionLayer.layer == "silver",
+        )
+    )
+    for old_layer in old.scalars().all():
+        await db.delete(old_layer)
+
+    layer = MedallionLayer(
+        id=_uid(),
+        user_id=user_id,
+        source_id=source.id,
+        agent_id=agent_id,
+        layer="silver",
+        table_name=silver_table,
+        status="ready",
+        schema_config=config,
+        ddl_sql=ddl,
+        transform_sql=transform,
+        row_count=row_count,
+    )
+    db.add(layer)
+
+    # Update build log
+    apply_log = MedallionBuildLog(
+        id=_uid(),
+        layer_id=layer.id,
+        source_id=source.id,
+        user_id=user_id,
+        action="apply",
+        layer="silver",
+        applied_config=config,
+    )
+    db.add(apply_log)
+    await db.flush()
+
+    return _layer_to_dict(layer)
+
+
+# ---------------------------------------------------------------------------
+# Gold — Suggest
+# ---------------------------------------------------------------------------
+
+_GOLD_SYSTEM_PROMPT = """\
+You are a data analyst. Given this Silver (cleaned) layer schema, suggest useful \
+business aggregate tables (Gold layer).
+
+Suggest 3-5 Gold tables with:
+1. **name**: short snake_case identifier (e.g., "monthly_revenue")
+2. **description**: one-line business explanation
+3. **sql**: A SELECT query against the silver table that creates this aggregate. \
+Use standard SQL (SQLite compatible). Include GROUP BY for aggregates.
+4. **dimensions**: list of grouping columns
+5. **measures**: list of {column, agg_func, alias} objects
+
+Return ONLY valid JSON:
+{
+  "suggestions": [
+    {
+      "name": "monthly_revenue",
+      "description": "Monthly revenue totals",
+      "sql": "SELECT strftime('%Y-%m', created_at) AS month, SUM(revenue) AS total_revenue ...",
+      "dimensions": ["month"],
+      "measures": [{"column": "revenue", "agg_func": "SUM", "alias": "total_revenue"}],
+      "explanation": "..."
+    }
+  ]
+}
+"""
+
+
+async def suggest_gold(
+    source: Source,
+    user_id: str,
+    agent_id: str,
+    data_files_dir: str,
+    db: AsyncSession,
+    llm_overrides: dict | None = None,
+    feedback: str | None = None,
+) -> dict:
+    """Use LLM to suggest gold aggregate tables. Returns {suggestions, buildLogId}."""
+    result = await db.execute(
+        select(MedallionLayer).where(
+            MedallionLayer.source_id == source.id,
+            MedallionLayer.layer == "silver",
+            MedallionLayer.status == "ready",
+        )
+    )
+    silver = result.scalar_one_or_none()
+    if not silver:
+        raise ValueError("Silver layer must be built first")
+
+    # Get silver schema from medallion DB
+    conn = _get_medallion_conn(data_files_dir, user_id, source.id)
+    try:
+        cursor = conn.execute(f'PRAGMA table_info("{silver.table_name}")')
+        columns = [(row[1], row[2]) for row in cursor.fetchall()]
+        df_sample = pd.read_sql_query(
+            f'SELECT * FROM "{silver.table_name}" LIMIT 5',
+            conn,
+        )
+    finally:
+        conn.close()
+
+    col_desc = "\n".join(f"- {name} ({dtype})" for name, dtype in columns)
+    sample_text = df_sample.to_string(index=False)
+
+    user_msg = f"""Silver table: {silver.table_name}
+Row count: {silver.row_count}
+
+Columns:
+{col_desc}
+
+Sample rows (first 5):
+{sample_text}
+"""
+
+    if feedback:
+        user_msg += f"\n\nUser feedback on previous suggestions — please adjust accordingly:\n{feedback}"
+
+    messages = [
+        {"role": "system", "content": _GOLD_SYSTEM_PROMPT},
+        {"role": "user", "content": user_msg},
+    ]
+
+    raw_content, usage, _trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+    parsed = _parse_json_response(raw_content)
+    suggestions = parsed.get("suggestions", [])
+
+    # Generate DDL previews
+    sid = _short_id(source.id)
+    ddl_previews = []
+    for s in suggestions:
+        gold_table = f"gold_{sid}_{s.get('name', 'agg')}"
+        sql = s.get("sql", "")
+        ddl = f'CREATE TABLE IF NOT EXISTS "{gold_table}" AS\n{sql};'
+        ddl_previews.append(ddl)
+
+    action = "redo" if feedback else "suggest"
+    build_log = MedallionBuildLog(
+        id=_uid(),
+        source_id=source.id,
+        user_id=user_id,
+        action=action,
+        layer="gold",
+        input_feedback=feedback,
+        suggestion={"suggestions": suggestions},
+        llm_usage=usage,
+    )
+    db.add(build_log)
+    await db.flush()
+
+    return {
+        "suggestions": suggestions,
+        "ddlPreviews": ddl_previews,
+        "buildLogId": build_log.id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Gold — Apply
+# ---------------------------------------------------------------------------
+
+async def apply_gold(
+    source: Source,
+    user_id: str,
+    agent_id: str,
+    data_files_dir: str,
+    db: AsyncSession,
+    build_log_id: str,
+    selected_tables: list[dict],
+) -> list[dict]:
+    """Materialize selected gold aggregate tables. Returns list of layer dicts."""
+    sid = _short_id(source.id)
+    layers = []
+
+    conn = _get_medallion_conn(data_files_dir, user_id, source.id)
+    try:
+        for tbl in selected_tables:
+            name = tbl.get("name", "agg")
+            sql = tbl.get("sql", "")
+            gold_table = f"gold_{sid}_{name}"
+
+            create_sql = f'CREATE TABLE IF NOT EXISTS "{gold_table}" AS\n{sql};'
+
+            try:
+                conn.execute(f'DROP TABLE IF EXISTS "{gold_table}"')
+                conn.execute(create_sql)
+                conn.commit()
+                cursor = conn.execute(f'SELECT COUNT(*) FROM "{gold_table}"')
+                row_count = cursor.fetchone()[0]
+            except Exception as e:
+                conn.rollback()
+                err_log = MedallionBuildLog(
+                    id=_uid(), source_id=source.id, user_id=user_id,
+                    action="error", layer="gold", error_message=f"{gold_table}: {e}",
+                )
+                db.add(err_log)
+                continue
+
+            layer = MedallionLayer(
+                id=_uid(),
+                user_id=user_id,
+                source_id=source.id,
+                agent_id=agent_id,
+                layer="gold",
+                table_name=gold_table,
+                status="ready",
+                schema_config=tbl,
+                ddl_sql=create_sql,
+                transform_sql=sql,
+                row_count=row_count,
+            )
+            db.add(layer)
+
+            apply_log = MedallionBuildLog(
+                id=_uid(),
+                layer_id=layer.id,
+                source_id=source.id,
+                user_id=user_id,
+                action="apply",
+                layer="gold",
+                applied_config=tbl,
+            )
+            db.add(apply_log)
+            layers.append(_layer_to_dict(layer))
+
+    finally:
+        conn.close()
+
+    await db.flush()
+    return layers
+
+
+# ---------------------------------------------------------------------------
+# Query helpers (for ask_csv query routing)
+# ---------------------------------------------------------------------------
+
+def get_medallion_connection(
+    data_files_dir: str, user_id: str, source_id: str
+) -> sqlite3.Connection | None:
+    """Return a connection to the medallion DB if it exists, else None."""
+    path = _medallion_db_path(data_files_dir, user_id, source_id)
+    if not path.exists():
+        return None
+    return sqlite3.connect(str(path))
+
+
+def list_medallion_tables(conn: sqlite3.Connection) -> dict[str, list[tuple[str, str]]]:
+    """Return {table_name: [(col_name, col_type), ...]} for all medallion tables."""
+    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = {}
+    for (tname,) in cursor.fetchall():
+        cols = conn.execute(f'PRAGMA table_info("{tname}")')
+        tables[tname] = [(r[1], r[2]) for r in cols.fetchall()]
+    return tables
+
+
+# ---------------------------------------------------------------------------
+# SQL Generation helpers
+# ---------------------------------------------------------------------------
+
+def _build_silver_ddl(config: dict, short_id: str) -> str:
+    """Generate CREATE TABLE for silver layer from config."""
+    silver_table = f"silver_{short_id}"
+    columns = config.get("columns", [])
+    col_defs = []
+    for col in columns:
+        name = col.get("silver_name", col.get("source_column", "unknown"))
+        dtype = col.get("target_type", "TEXT")
+        safe_name = name.replace('"', '""')
+        col_defs.append(f'  "{safe_name}" {dtype}')
+
+    if not col_defs:
+        return f'CREATE TABLE IF NOT EXISTS "{silver_table}" (id TEXT);'
+
+    return f'CREATE TABLE IF NOT EXISTS "{silver_table}" (\n' + ",\n".join(col_defs) + "\n);"
+
+
+def _build_silver_transform(config: dict, bronze_table: str, silver_table: str) -> str:
+    """Generate INSERT INTO ... SELECT for silver layer from config."""
+    columns = config.get("columns", [])
+    dedup_key = config.get("dedup_key", [])
+    dedup_order = config.get("dedup_order_by")
+
+    select_exprs = []
+    target_cols = []
+    for col in columns:
+        expr = col.get("cast_expression", f'"{col.get("source_column", "")}"')
+        alias = col.get("silver_name", col.get("source_column", ""))
+        safe_alias = alias.replace('"', '""')
+        target_cols.append(f'"{safe_alias}"')
+
+        # Apply null strategy
+        null_strategy = col.get("null_strategy", "KEEP_NULL")
+        null_default = col.get("null_default")
+
+        if null_strategy == "FILL_ZERO":
+            expr = f"COALESCE({expr}, 0)"
+        elif null_strategy == "FILL_DEFAULT" and null_default is not None:
+            expr = f"COALESCE({expr}, '{null_default}')"
+        elif null_strategy == "DROP_ROW":
+            pass  # handled in WHERE clause
+
+        select_exprs.append(f"  {expr} AS \"{safe_alias}\"")
+
+    select_clause = ",\n".join(select_exprs)
+
+    # WHERE clause for DROP_ROW columns
+    drop_conditions = []
+    for col in columns:
+        if col.get("null_strategy") == "DROP_ROW":
+            src = col.get("source_column", "")
+            drop_conditions.append(f'"{src}" IS NOT NULL')
+
+    where_clause = ""
+    if drop_conditions:
+        where_clause = "\nWHERE " + " AND ".join(drop_conditions)
+
+    # Deduplication via subquery
+    if dedup_key and dedup_order:
+        key_cols = ", ".join(f'"{k}"' for k in dedup_key)
+        inner = f"""SELECT *, ROW_NUMBER() OVER (PARTITION BY {key_cols} ORDER BY "{dedup_order}" DESC) AS _rn
+FROM "{bronze_table}"{where_clause}"""
+        sql = f"""INSERT INTO "{silver_table}" ({', '.join(target_cols)})
+SELECT
+{select_clause}
+FROM ({inner}) sub
+WHERE _rn = 1;"""
+    else:
+        sql = f"""INSERT INTO "{silver_table}" ({', '.join(target_cols)})
+SELECT
+{select_clause}
+FROM "{bronze_table}"{where_clause};"""
+
+    return sql
+
+
+def _parse_json_response(raw: str) -> dict:
+    """Extract JSON object from LLM response, handling markdown fences."""
+    text = raw.strip()
+    # Strip markdown code fences
+    if text.startswith("```"):
+        lines = text.split("\n")
+        # Remove first and last fence lines
+        if lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        text = "\n".join(lines)
+
+    # Find JSON object boundaries
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            return json.loads(text[start : end + 1])
+        except json.JSONDecodeError:
+            pass
+
+    log.warning("Failed to parse LLM JSON response, returning empty dict")
+    return {}

--- a/src/components/MedallionPanel.tsx
+++ b/src/components/MedallionPanel.tsx
@@ -1,0 +1,834 @@
+/**
+ * MedallionPanel — AI-Assisted Bronze / Silver / Gold layer management.
+ *
+ * Opened from StudioPanel as a Dialog. Users can:
+ * 1. Generate Bronze layer (raw staging)
+ * 2. Get AI-suggested Silver schema, edit it, redo with feedback, then apply
+ * 3. Get AI-suggested Gold aggregates, select which to materialize
+ * 4. View all generated SQL and build history
+ */
+import { useState, useEffect, useCallback } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Card } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Layers,
+  Database,
+  Sparkles,
+  Trophy,
+  Loader2,
+  RefreshCw,
+  Check,
+  AlertCircle,
+  History,
+  Copy,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import type {
+  MedallionLayerOut,
+  MedallionBuildLogOut,
+  SilverColumnSuggestion,
+  SilverSuggestResponse,
+  GoldTableSuggestion,
+  GoldSuggestResponse,
+} from "@/services/apiClient";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SourceOption {
+  id: string;
+  name: string;
+  type: string;
+}
+
+interface MedallionPanelProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agentId: string;
+  sourceId?: string;
+  sourceName?: string;
+}
+
+type LayerStatus = "none" | "pending" | "ready" | "error";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function statusBadge(status: LayerStatus) {
+  if (status === "ready")
+    return <Badge variant="default" className="bg-green-600 text-white"><Check className="h-3 w-3 mr-1" /> Ready</Badge>;
+  if (status === "pending")
+    return <Badge variant="secondary"><Loader2 className="h-3 w-3 mr-1 animate-spin" /> Building</Badge>;
+  if (status === "error")
+    return <Badge variant="destructive"><AlertCircle className="h-3 w-3 mr-1" /> Error</Badge>;
+  return <Badge variant="outline">Not built</Badge>;
+}
+
+function SqlViewer({ label, sql }: { label: string; sql: string }) {
+  return (
+    <div className="relative">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-xs text-muted-foreground font-medium">{label}</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={() => {
+            navigator.clipboard.writeText(sql);
+            toast.info("SQL copied");
+          }}
+        >
+          <Copy className="h-3 w-3" />
+        </Button>
+      </div>
+      <pre className="bg-muted rounded-md p-3 text-xs overflow-x-auto max-h-48 whitespace-pre-wrap font-mono">
+        {sql}
+      </pre>
+    </div>
+  );
+}
+
+const SQL_TYPES = ["TEXT", "INTEGER", "REAL", "BOOLEAN", "DATE", "TIMESTAMP", "DECIMAL"];
+const NULL_STRATEGIES = ["KEEP_NULL", "DROP_ROW", "FILL_ZERO", "FILL_DEFAULT"];
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function MedallionPanel({
+  open,
+  onOpenChange,
+  agentId,
+  sourceId,
+  sourceName,
+}: MedallionPanelProps) {
+  const { t } = useLanguage();
+
+  // Source selector (when sourceId prop is empty, loads from agent)
+  const [sources, setSources] = useState<SourceOption[]>([]);
+  const [selectedSourceId, setSelectedSourceId] = useState(sourceId || "");
+  const [selectedSourceName, setSelectedSourceName] = useState(sourceName || "");
+  const effectiveSourceId = sourceId || selectedSourceId;
+
+  // Layer states
+  const [layers, setLayers] = useState<MedallionLayerOut[]>([]);
+  const [logs, setLogs] = useState<MedallionBuildLogOut[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState("bronze");
+
+  // Bronze
+  const [bronzeLoading, setBronzeLoading] = useState(false);
+
+  // Silver
+  const [silverSuggestion, setSilverSuggestion] = useState<SilverSuggestResponse | null>(null);
+  const [silverColumns, setSilverColumns] = useState<SilverColumnSuggestion[]>([]);
+  const [silverDedupKey, setSilverDedupKey] = useState<string[]>([]);
+  const [silverDedupOrder, setSilverDedupOrder] = useState<string>("");
+  const [silverFeedback, setSilverFeedback] = useState("");
+  const [silverLoading, setSilverLoading] = useState(false);
+  const [silverApplying, setSilverApplying] = useState(false);
+
+  // Gold
+  const [goldSuggestion, setGoldSuggestion] = useState<GoldSuggestResponse | null>(null);
+  const [goldSelected, setGoldSelected] = useState<Set<number>>(new Set());
+  const [goldFeedback, setGoldFeedback] = useState("");
+  const [goldLoading, setGoldLoading] = useState(false);
+  const [goldApplying, setGoldApplying] = useState(false);
+
+  // History panel
+  const [showHistory, setShowHistory] = useState(false);
+
+  // Derived statuses
+  const bronzeLayer = layers.find((l) => l.layer === "bronze");
+  const silverLayer = layers.find((l) => l.layer === "silver");
+  const goldLayers = layers.filter((l) => l.layer === "gold");
+  const bronzeStatus: LayerStatus = bronzeLayer?.status as LayerStatus || "none";
+  const silverStatus: LayerStatus = silverLayer?.status as LayerStatus || "none";
+  const goldStatus: LayerStatus = goldLayers.length > 0 ? "ready" : "none";
+
+  // ---------------------------------------------------------------------------
+  // Data fetching
+  // ---------------------------------------------------------------------------
+
+  // Load sources when no sourceId prop
+  useEffect(() => {
+    if (!open || sourceId) return;
+    (async () => {
+      try {
+        const list = await dataClient.listSources(agentId, true);
+        const fileTypes = ["csv", "xlsx", "parquet", "json", "sqlite"];
+        const filtered = (list || []).filter((s: { type: string }) => fileTypes.includes(s.type));
+        setSources(filtered.map((s: { id: string; name: string; type: string }) => ({ id: s.id, name: s.name, type: s.type })));
+        if (filtered.length === 1) {
+          setSelectedSourceId(filtered[0].id);
+          setSelectedSourceName(filtered[0].name);
+        }
+      } catch { /* silent */ }
+    })();
+  }, [open, agentId, sourceId]);
+
+  const refresh = useCallback(async () => {
+    if (!effectiveSourceId) return;
+    setLoading(true);
+    try {
+      const [layerData, logData] = await Promise.all([
+        dataClient.medallionListLayers(effectiveSourceId),
+        dataClient.medallionListLogs(effectiveSourceId),
+      ]);
+      setLayers(layerData);
+      setLogs(logData);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+    }
+  }, [effectiveSourceId]);
+
+  useEffect(() => {
+    if (open && effectiveSourceId) refresh();
+  }, [open, effectiveSourceId, refresh]);
+
+  // ---------------------------------------------------------------------------
+  // Bronze
+  // ---------------------------------------------------------------------------
+
+  async function handleGenerateBronze() {
+    setBronzeLoading(true);
+    try {
+      await dataClient.medallionGenerateBronze({ sourceId: effectiveSourceId, agentId });
+      toast.success("Bronze layer generated");
+      await refresh();
+      setActiveTab("silver");
+    } catch (e: unknown) {
+      toast.error("Error generating bronze", { description: (e as Error)?.message });
+    } finally {
+      setBronzeLoading(false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Silver — suggest / edit / redo / apply
+  // ---------------------------------------------------------------------------
+
+  async function handleSuggestSilver(feedback?: string) {
+    setSilverLoading(true);
+    try {
+      const result = await dataClient.medallionSuggestSilver({
+        sourceId: effectiveSourceId,
+        agentId,
+        feedback: feedback || undefined,
+      });
+      setSilverSuggestion(result);
+      setSilverColumns(result.suggestion.columns || []);
+      setSilverDedupKey(result.suggestion.dedup_key || []);
+      setSilverDedupOrder(result.suggestion.dedup_order_by || "");
+      setSilverFeedback("");
+      toast.success(feedback ? "Schema re-suggested with your feedback" : "Silver schema suggested");
+      await refresh();
+    } catch (e: unknown) {
+      toast.error("Error suggesting silver schema", { description: (e as Error)?.message });
+    } finally {
+      setSilverLoading(false);
+    }
+  }
+
+  function updateSilverColumn(idx: number, field: keyof SilverColumnSuggestion, value: string) {
+    setSilverColumns((prev) => {
+      const copy = [...prev];
+      copy[idx] = { ...copy[idx], [field]: value };
+      return copy;
+    });
+  }
+
+  function toggleDedupKey(col: string) {
+    setSilverDedupKey((prev) =>
+      prev.includes(col) ? prev.filter((c) => c !== col) : [...prev, col]
+    );
+  }
+
+  async function handleApplySilver() {
+    if (!silverSuggestion) return;
+    setSilverApplying(true);
+    try {
+      await dataClient.medallionApplySilver({
+        sourceId: effectiveSourceId,
+        agentId,
+        buildLogId: silverSuggestion.buildLogId,
+        config: {
+          columns: silverColumns,
+          dedup_key: silverDedupKey,
+          dedup_order_by: silverDedupOrder || null,
+        },
+      });
+      toast.success("Silver layer applied");
+      setSilverSuggestion(null);
+      await refresh();
+      setActiveTab("gold");
+    } catch (e: unknown) {
+      toast.error("Error applying silver layer", { description: (e as Error)?.message });
+    } finally {
+      setSilverApplying(false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Gold — suggest / select / redo / apply
+  // ---------------------------------------------------------------------------
+
+  async function handleSuggestGold(feedback?: string) {
+    setGoldLoading(true);
+    try {
+      const result = await dataClient.medallionSuggestGold({
+        sourceId: effectiveSourceId,
+        agentId,
+        feedback: feedback || undefined,
+      });
+      setGoldSuggestion(result);
+      setGoldSelected(new Set(result.suggestions.map((_, i) => i)));
+      setGoldFeedback("");
+      toast.success(feedback ? "Aggregates re-suggested with your feedback" : "Gold aggregates suggested");
+      await refresh();
+    } catch (e: unknown) {
+      toast.error("Error suggesting gold aggregates", { description: (e as Error)?.message });
+    } finally {
+      setGoldLoading(false);
+    }
+  }
+
+  function toggleGoldSelection(idx: number) {
+    setGoldSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }
+
+  async function handleApplyGold() {
+    if (!goldSuggestion) return;
+    setGoldApplying(true);
+    try {
+      const selected = goldSuggestion.suggestions.filter((_, i) => goldSelected.has(i));
+      await dataClient.medallionApplyGold({
+        sourceId: effectiveSourceId,
+        agentId,
+        buildLogId: goldSuggestion.buildLogId,
+        selectedTables: selected,
+      });
+      toast.success("Gold layers materialized");
+      setGoldSuggestion(null);
+      await refresh();
+    } catch (e: unknown) {
+      toast.error("Error applying gold layers", { description: (e as Error)?.message });
+    } finally {
+      setGoldApplying(false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl max-h-[90vh] h-[780px] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Layers className="h-5 w-5" />
+            Medallion Architecture
+          </DialogTitle>
+          <DialogDescription>
+            {selectedSourceName ? `Source: ${selectedSourceName}` : "Build Bronze → Silver → Gold data layers"}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Source selector (when no sourceId prop) */}
+        {!sourceId && sources.length > 1 && (
+          <div className="px-1">
+            <Select value={selectedSourceId} onValueChange={(v) => {
+              setSelectedSourceId(v);
+              setSelectedSourceName(sources.find(s => s.id === v)?.name || "");
+              setLayers([]);
+              setLogs([]);
+              setSilverSuggestion(null);
+              setGoldSuggestion(null);
+            }}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select a data source..." />
+              </SelectTrigger>
+              <SelectContent>
+                {sources.map((s) => (
+                  <SelectItem key={s.id} value={s.id}>{s.name} ({s.type})</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {!effectiveSourceId && sources.length === 0 && (
+          <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+            No file-based sources found. Upload a CSV or XLSX file first.
+          </div>
+        )}
+
+        {/* Progress indicators */}
+        {effectiveSourceId && <><div className="flex items-center gap-2 px-1">
+          <div className="flex items-center gap-1">
+            <Database className="h-4 w-4" />
+            <span className="text-xs">Bronze</span>
+            {statusBadge(bronzeStatus)}
+          </div>
+          <span className="text-muted-foreground">→</span>
+          <div className="flex items-center gap-1">
+            <Sparkles className="h-4 w-4" />
+            <span className="text-xs">Silver</span>
+            {statusBadge(silverStatus)}
+          </div>
+          <span className="text-muted-foreground">→</span>
+          <div className="flex items-center gap-1">
+            <Trophy className="h-4 w-4" />
+            <span className="text-xs">Gold</span>
+            {statusBadge(goldStatus)}
+          </div>
+          <div className="ml-auto">
+            <Button variant="ghost" size="sm" onClick={() => setShowHistory(!showHistory)}>
+              <History className="h-4 w-4 mr-1" />
+              {showHistory ? "Hide" : "History"}
+            </Button>
+          </div>
+        </div>
+
+        {/* Main content */}
+        <div className="flex-1 min-h-0 flex gap-3">
+          {/* Tabs area */}
+          <div className={showHistory ? "flex-1 min-w-0" : "w-full"}>
+            <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
+              <TabsList className="w-full">
+                <TabsTrigger value="bronze" className="flex-1">Bronze</TabsTrigger>
+                <TabsTrigger value="silver" className="flex-1" disabled={bronzeStatus !== "ready"}>
+                  Silver
+                </TabsTrigger>
+                <TabsTrigger value="gold" className="flex-1" disabled={silverStatus !== "ready"}>
+                  Gold
+                </TabsTrigger>
+              </TabsList>
+
+              {/* ─── Bronze Tab ─── */}
+              <TabsContent value="bronze" className="flex-1 overflow-y-auto mt-3 space-y-4">
+                {bronzeStatus === "none" ? (
+                  <div className="text-center py-8 space-y-4">
+                    <Database className="h-12 w-12 mx-auto text-muted-foreground" />
+                    <p className="text-sm text-muted-foreground">
+                      Generate a Bronze layer to stage raw data with metadata columns.
+                    </p>
+                    <Button onClick={handleGenerateBronze} disabled={bronzeLoading}>
+                      {bronzeLoading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                      Generate Bronze Layer
+                    </Button>
+                  </div>
+                ) : bronzeLayer ? (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <span className="text-sm font-medium">Table: </span>
+                        <code className="text-sm bg-muted px-2 py-0.5 rounded">{bronzeLayer.tableName}</code>
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {bronzeLayer.rowCount?.toLocaleString()} rows
+                      </div>
+                    </div>
+
+                    {/* Columns list */}
+                    {bronzeLayer.schemaConfig?.columns && (
+                      <div>
+                        <span className="text-xs text-muted-foreground font-medium">Columns ({(bronzeLayer.schemaConfig.columns as string[]).length})</span>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {(bronzeLayer.schemaConfig.columns as string[]).map((col) => (
+                            <Badge key={col} variant="outline" className="text-xs">{col}</Badge>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    <Accordion type="single" collapsible>
+                      <AccordionItem value="ddl">
+                        <AccordionTrigger className="text-sm">View DDL SQL</AccordionTrigger>
+                        <AccordionContent>
+                          <SqlViewer label="CREATE TABLE" sql={bronzeLayer.ddlSql} />
+                        </AccordionContent>
+                      </AccordionItem>
+                    </Accordion>
+                  </div>
+                ) : null}
+              </TabsContent>
+
+              {/* ─── Silver Tab ─── */}
+              <TabsContent value="silver" className="flex-1 overflow-y-auto mt-3 space-y-4">
+                {silverStatus === "ready" && silverLayer && !silverSuggestion ? (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <span className="text-sm font-medium">Table: </span>
+                        <code className="text-sm bg-muted px-2 py-0.5 rounded">{silverLayer.tableName}</code>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">{silverLayer.rowCount?.toLocaleString()} rows</span>
+                        <Button variant="outline" size="sm" onClick={() => handleSuggestSilver()}>
+                          <RefreshCw className="h-3 w-3 mr-1" /> Re-suggest
+                        </Button>
+                      </div>
+                    </div>
+                    <Accordion type="multiple">
+                      <AccordionItem value="ddl">
+                        <AccordionTrigger className="text-sm">View DDL SQL</AccordionTrigger>
+                        <AccordionContent>
+                          <SqlViewer label="CREATE TABLE" sql={silverLayer.ddlSql} />
+                        </AccordionContent>
+                      </AccordionItem>
+                      {silverLayer.transformSql && (
+                        <AccordionItem value="transform">
+                          <AccordionTrigger className="text-sm">View Transform SQL</AccordionTrigger>
+                          <AccordionContent>
+                            <SqlViewer label="INSERT INTO ... SELECT" sql={silverLayer.transformSql} />
+                          </AccordionContent>
+                        </AccordionItem>
+                      )}
+                    </Accordion>
+                  </div>
+                ) : !silverSuggestion ? (
+                  <div className="text-center py-8 space-y-4">
+                    <Sparkles className="h-12 w-12 mx-auto text-muted-foreground" />
+                    <p className="text-sm text-muted-foreground">
+                      AI will analyze your data and suggest type casting, null handling, deduplication, and naming.
+                    </p>
+                    <Button onClick={() => handleSuggestSilver()} disabled={silverLoading}>
+                      {silverLoading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                      Suggest Silver Schema
+                    </Button>
+                  </div>
+                ) : (
+                  /* Editable suggestion */
+                  <div className="space-y-4">
+                    {silverSuggestion.suggestion.explanation && (
+                      <p className="text-sm text-muted-foreground bg-muted/50 p-3 rounded-md">
+                        {silverSuggestion.suggestion.explanation}
+                      </p>
+                    )}
+
+                    {/* Editable columns table */}
+                    <ScrollArea className="max-h-[280px] border rounded-md">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead className="w-[120px]">Source</TableHead>
+                            <TableHead className="w-[120px]">Silver Name</TableHead>
+                            <TableHead className="w-[110px]">Type</TableHead>
+                            <TableHead className="w-[120px]">Null Strategy</TableHead>
+                            <TableHead className="w-[60px]">Dedup</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {silverColumns.map((col, idx) => (
+                            <TableRow key={idx}>
+                              <TableCell className="text-xs font-mono">{col.source_column}</TableCell>
+                              <TableCell>
+                                <Input
+                                  className="h-7 text-xs"
+                                  value={col.silver_name}
+                                  onChange={(e) => updateSilverColumn(idx, "silver_name", e.target.value)}
+                                />
+                              </TableCell>
+                              <TableCell>
+                                <Select
+                                  value={col.target_type}
+                                  onValueChange={(v) => updateSilverColumn(idx, "target_type", v)}
+                                >
+                                  <SelectTrigger className="h-7 text-xs">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {SQL_TYPES.map((t) => (
+                                      <SelectItem key={t} value={t} className="text-xs">{t}</SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </TableCell>
+                              <TableCell>
+                                <Select
+                                  value={col.null_strategy}
+                                  onValueChange={(v) => updateSilverColumn(idx, "null_strategy", v)}
+                                >
+                                  <SelectTrigger className="h-7 text-xs">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {NULL_STRATEGIES.map((s) => (
+                                      <SelectItem key={s} value={s} className="text-xs">{s}</SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </TableCell>
+                              <TableCell className="text-center">
+                                <Checkbox
+                                  checked={silverDedupKey.includes(col.source_column)}
+                                  onCheckedChange={() => toggleDedupKey(col.source_column)}
+                                />
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </ScrollArea>
+
+                    {/* SQL Previews */}
+                    <Accordion type="multiple">
+                      <AccordionItem value="ddl-preview">
+                        <AccordionTrigger className="text-sm">DDL Preview</AccordionTrigger>
+                        <AccordionContent>
+                          <SqlViewer label="CREATE TABLE" sql={silverSuggestion.ddlPreview} />
+                        </AccordionContent>
+                      </AccordionItem>
+                      <AccordionItem value="transform-preview">
+                        <AccordionTrigger className="text-sm">Transform Preview</AccordionTrigger>
+                        <AccordionContent>
+                          <SqlViewer label="INSERT INTO ... SELECT" sql={silverSuggestion.transformPreview} />
+                        </AccordionContent>
+                      </AccordionItem>
+                    </Accordion>
+
+                    {/* Redo with feedback */}
+                    <div className="border rounded-md p-3 space-y-2">
+                      <span className="text-xs font-medium text-muted-foreground">Redo with feedback</span>
+                      <div className="flex gap-2">
+                        <Textarea
+                          className="text-xs min-h-[60px]"
+                          placeholder="e.g. Use DATE for date columns, rename 'amt' to 'amount_usd'..."
+                          value={silverFeedback}
+                          onChange={(e) => setSilverFeedback(e.target.value)}
+                        />
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleSuggestSilver(silverFeedback)}
+                        disabled={silverLoading || !silverFeedback.trim()}
+                      >
+                        {silverLoading && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
+                        <RefreshCw className="h-3 w-3 mr-1" /> Re-suggest
+                      </Button>
+                    </div>
+
+                    {/* Apply */}
+                    <Button onClick={handleApplySilver} disabled={silverApplying} className="w-full">
+                      {silverApplying && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                      Apply Silver Layer
+                    </Button>
+                  </div>
+                )}
+              </TabsContent>
+
+              {/* ─── Gold Tab ─── */}
+              <TabsContent value="gold" className="flex-1 overflow-y-auto mt-3 space-y-4">
+                {/* Existing gold layers */}
+                {goldLayers.length > 0 && !goldSuggestion && (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium">{goldLayers.length} Gold table(s)</span>
+                      <Button variant="outline" size="sm" onClick={() => handleSuggestGold()}>
+                        <RefreshCw className="h-3 w-3 mr-1" /> Suggest more
+                      </Button>
+                    </div>
+                    {goldLayers.map((gl) => (
+                      <Card key={gl.id} className="p-3 space-y-2">
+                        <div className="flex items-center justify-between">
+                          <code className="text-sm bg-muted px-2 py-0.5 rounded">{gl.tableName}</code>
+                          <span className="text-xs text-muted-foreground">{gl.rowCount?.toLocaleString()} rows</span>
+                        </div>
+                        {gl.schemaConfig?.description && (
+                          <p className="text-xs text-muted-foreground">{gl.schemaConfig.description as string}</p>
+                        )}
+                        <Accordion type="single" collapsible>
+                          <AccordionItem value="sql">
+                            <AccordionTrigger className="text-xs">View SQL</AccordionTrigger>
+                            <AccordionContent>
+                              <SqlViewer label="CREATE TABLE AS" sql={gl.ddlSql} />
+                            </AccordionContent>
+                          </AccordionItem>
+                        </Accordion>
+                      </Card>
+                    ))}
+                  </div>
+                )}
+
+                {/* No gold + no suggestion yet */}
+                {goldLayers.length === 0 && !goldSuggestion && (
+                  <div className="text-center py-8 space-y-4">
+                    <Trophy className="h-12 w-12 mx-auto text-muted-foreground" />
+                    <p className="text-sm text-muted-foreground">
+                      AI will suggest business aggregate tables based on your Silver schema.
+                    </p>
+                    <Button onClick={() => handleSuggestGold()} disabled={goldLoading}>
+                      {goldLoading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                      Suggest Gold Aggregates
+                    </Button>
+                  </div>
+                )}
+
+                {/* Gold suggestions */}
+                {goldSuggestion && (
+                  <div className="space-y-3">
+                    {goldSuggestion.suggestions.map((s, idx) => (
+                      <Card
+                        key={idx}
+                        className={`p-3 cursor-pointer transition-colors ${
+                          goldSelected.has(idx) ? "border-primary bg-primary/5" : ""
+                        }`}
+                        onClick={() => toggleGoldSelection(idx)}
+                      >
+                        <div className="flex items-start gap-3">
+                          <Checkbox
+                            checked={goldSelected.has(idx)}
+                            onCheckedChange={() => toggleGoldSelection(idx)}
+                            className="mt-0.5"
+                          />
+                          <div className="flex-1 min-w-0 space-y-1">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium text-sm">{s.name}</span>
+                              {s.dimensions?.map((d) => (
+                                <Badge key={d} variant="outline" className="text-[10px]">{d}</Badge>
+                              ))}
+                            </div>
+                            <p className="text-xs text-muted-foreground">{s.description}</p>
+                            {s.measures && (
+                              <div className="flex gap-1 flex-wrap">
+                                {s.measures.map((m, mi) => (
+                                  <Badge key={mi} variant="secondary" className="text-[10px]">
+                                    {m.agg_func}({m.column})
+                                  </Badge>
+                                ))}
+                              </div>
+                            )}
+                            <Accordion type="single" collapsible>
+                              <AccordionItem value="sql">
+                                <AccordionTrigger className="text-xs py-1">SQL</AccordionTrigger>
+                                <AccordionContent>
+                                  <pre className="bg-muted rounded p-2 text-[10px] font-mono overflow-x-auto whitespace-pre-wrap">
+                                    {s.sql}
+                                  </pre>
+                                </AccordionContent>
+                              </AccordionItem>
+                            </Accordion>
+                          </div>
+                        </div>
+                      </Card>
+                    ))}
+
+                    {/* Redo feedback */}
+                    <div className="border rounded-md p-3 space-y-2">
+                      <span className="text-xs font-medium text-muted-foreground">Redo with feedback</span>
+                      <Textarea
+                        className="text-xs min-h-[60px]"
+                        placeholder="e.g. Add a weekly cohort analysis table, group revenue by product category..."
+                        value={goldFeedback}
+                        onChange={(e) => setGoldFeedback(e.target.value)}
+                      />
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleSuggestGold(goldFeedback)}
+                        disabled={goldLoading || !goldFeedback.trim()}
+                      >
+                        {goldLoading && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
+                        <RefreshCw className="h-3 w-3 mr-1" /> Re-suggest
+                      </Button>
+                    </div>
+
+                    <Button
+                      onClick={handleApplyGold}
+                      disabled={goldApplying || goldSelected.size === 0}
+                      className="w-full"
+                    >
+                      {goldApplying && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                      Materialize {goldSelected.size} Selected Table(s)
+                    </Button>
+                  </div>
+                )}
+              </TabsContent>
+            </Tabs>
+          </div>
+
+          {/* Build history sidebar */}
+          {showHistory && (
+            <div className="w-72 border-l pl-3 flex flex-col">
+              <span className="text-sm font-medium mb-2">Build History</span>
+              <ScrollArea className="flex-1">
+                <div className="space-y-2 pr-2">
+                  {logs.map((entry) => (
+                    <div key={entry.id} className="border rounded p-2 space-y-1">
+                      <div className="flex items-center gap-1">
+                        <Badge variant={entry.action === "apply" ? "default" : entry.action === "error" ? "destructive" : "secondary"} className="text-[10px]">
+                          {entry.action}
+                        </Badge>
+                        <Badge variant="outline" className="text-[10px]">{entry.layer}</Badge>
+                      </div>
+                      {entry.inputFeedback && (
+                        <p className="text-[10px] text-muted-foreground italic">"{entry.inputFeedback}"</p>
+                      )}
+                      {entry.errorMessage && (
+                        <p className="text-[10px] text-destructive">{entry.errorMessage}</p>
+                      )}
+                      <span className="text-[10px] text-muted-foreground">
+                        {entry.createdAt ? new Date(entry.createdAt).toLocaleString() : ""}
+                      </span>
+                    </div>
+                  ))}
+                  {logs.length === 0 && (
+                    <p className="text-xs text-muted-foreground text-center py-4">No history yet</p>
+                  )}
+                </div>
+              </ScrollArea>
+            </div>
+          )}
+        </div></>}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/StudioPanel.tsx
+++ b/src/components/StudioPanel.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useLanguage } from "@/contexts/LanguageContext";
-import { AudioWaveform, Bell, ChevronRight, FileBarChart, FileText, GitBranch, Hash, LayoutTemplate, Lock, MessageCircle, Network, Send, Terminal } from "lucide-react";
+import { AudioWaveform, Bell, ChevronRight, FileBarChart, FileText, GitBranch, Hash, Layers, LayoutTemplate, Lock, MessageCircle, Network, Send, Terminal } from "lucide-react";
 import { toast } from "sonner";
 
 interface StudioPanelProps {
@@ -16,11 +16,12 @@ interface StudioPanelProps {
   onOpenTemplates?: () => void;
   onOpenSlack?: () => void;
   onOpenApiAccess?: () => void;
+  onOpenMedallion?: () => void;
   collapsed?: boolean;
   onToggleCollapse?: () => void;
 }
 
-export function StudioPanel({ onAddNote, onOpenGraph, onOpenSummary, onOpenAudio, onOpenAutoML, onOpenReport, onOpenTemplates, onOpenTelegram, onOpenWhatsApp, onOpenSlack, onOpenApiAccess, collapsed, onToggleCollapse }: StudioPanelProps) {
+export function StudioPanel({ onAddNote, onOpenGraph, onOpenSummary, onOpenAudio, onOpenAutoML, onOpenReport, onOpenTemplates, onOpenTelegram, onOpenWhatsApp, onOpenSlack, onOpenApiAccess, onOpenMedallion, collapsed, onToggleCollapse }: StudioPanelProps) {
   const { t } = useLanguage();
   
   const studioOptions: Array<{
@@ -50,6 +51,13 @@ export function StudioPanel({ onAddNote, onOpenGraph, onOpenSummary, onOpenAudio
       description: t('studio.audioOverview'),
       locked: false,
       onClick: onOpenAudio,
+    },
+    {
+      icon: Layers,
+      title: "Medallion",
+      description: "Bronze → Silver → Gold",
+      locked: false,
+      onClick: onOpenMedallion,
     },
     {
       icon: Network,

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -15,6 +15,7 @@ import { WhatsAppModal } from "@/components/WhatsAppModal";
 import { SlackModal } from "@/components/SlackModal";
 import { ApiAccessModal } from "@/components/ApiAccessModal";
 import { AutoMLModal } from "@/components/AutoMLModal";
+import { MedallionPanel } from "@/components/MedallionPanel";
 import { ReportModal } from "@/components/ReportModal";
 import { TemplateModal } from "@/components/TemplateModal";
 import { Badge } from "@/components/ui/badge";
@@ -297,6 +298,7 @@ export default function Workspace() {
   const [summaryModalOpen, setSummaryModalOpen] = useState(false);
   const [audioOverviewModalOpen, setAudioOverviewModalOpen] = useState(false);
   const [autoMLModalOpen, setAutoMLModalOpen] = useState(false);
+  const [medallionOpen, setMedallionOpen] = useState(false);
   const [reportModalOpen, setReportModalOpen] = useState(false);
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [logsModalOpen, setLogsModalOpen] = useState(false);
@@ -1091,6 +1093,7 @@ export default function Workspace() {
               onOpenWhatsApp={() => setIsWhatsAppModalOpen(true)}
               onOpenSlack={() => setIsSlackModalOpen(true)}
               onOpenApiAccess={() => setIsApiAccessModalOpen(true)}
+              onOpenMedallion={() => setMedallionOpen(true)}
             />
           </div>}
 
@@ -1182,6 +1185,13 @@ export default function Workspace() {
         open={autoMLModalOpen}
         onOpenChange={setAutoMLModalOpen}
         workspaceId={id || ''}
+      />
+
+      <MedallionPanel
+        open={medallionOpen}
+        onOpenChange={setMedallionOpen}
+        agentId={id || ''}
+        sourceId=""
       />
 
       <ReportModal

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -13,6 +13,72 @@ export interface SqlSourceRelationship {
   rightColumn: string;
 }
 
+// Medallion Architecture types
+export interface MedallionLayerOut {
+  id: string;
+  sourceId: string;
+  agentId: string;
+  layer: 'bronze' | 'silver' | 'gold';
+  tableName: string;
+  status: 'pending' | 'ready' | 'error';
+  schemaConfig: Record<string, unknown>;
+  ddlSql: string;
+  transformSql?: string | null;
+  rowCount?: number | null;
+  errorMessage?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface MedallionBuildLogOut {
+  id: string;
+  layerId?: string | null;
+  action: string;
+  layer: string;
+  inputFeedback?: string | null;
+  suggestion?: Record<string, unknown> | null;
+  appliedConfig?: Record<string, unknown> | null;
+  llmUsage?: Record<string, unknown> | null;
+  errorMessage?: string | null;
+  createdAt?: string | null;
+}
+
+export interface SilverColumnSuggestion {
+  source_column: string;
+  silver_name: string;
+  target_type: string;
+  cast_expression: string;
+  null_strategy: string;
+  null_default?: string | null;
+}
+
+export interface SilverSuggestResponse {
+  suggestion: {
+    columns: SilverColumnSuggestion[];
+    dedup_key: string[];
+    dedup_order_by?: string | null;
+    explanation?: string;
+  };
+  ddlPreview: string;
+  transformPreview: string;
+  buildLogId: string;
+}
+
+export interface GoldTableSuggestion {
+  name: string;
+  description: string;
+  sql: string;
+  dimensions: string[];
+  measures: { column: string; agg_func: string; alias: string }[];
+  explanation?: string;
+}
+
+export interface GoldSuggestResponse {
+  suggestions: GoldTableSuggestion[];
+  ddlPreviews: string[];
+  buildLogId: string;
+}
+
 function toApiAssetUrl(path?: string | null): string | undefined {
   if (!path) return undefined;
   if (/^https?:\/\//i.test(path) || path.startsWith('blob:') || path.startsWith('data:')) return path;
@@ -1322,5 +1388,60 @@ export const apiClient = {
     return api<{ ok: boolean }>(`/api/templates/sources/${sourceId}/templates/${templateId}/customize`, {
       method: 'DELETE',
     });
+  },
+
+  // -----------------------------------------------------------------------
+  // Medallion Architecture
+  // -----------------------------------------------------------------------
+
+  async medallionListLayers(sourceId: string) {
+    return api<MedallionLayerOut[]>(`/api/medallion/sources/${sourceId}/layers`);
+  },
+
+  async medallionListLogs(sourceId: string) {
+    return api<MedallionBuildLogOut[]>(`/api/medallion/sources/${sourceId}/logs`);
+  },
+
+  async medallionGetLayer(layerId: string) {
+    return api<MedallionLayerOut>(`/api/medallion/layers/${layerId}`);
+  },
+
+  async medallionGenerateBronze(body: { sourceId: string; agentId: string }) {
+    return api<MedallionLayerOut>('/api/medallion/bronze/generate', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+
+  async medallionSuggestSilver(body: { sourceId: string; agentId: string; feedback?: string }) {
+    return api<SilverSuggestResponse>('/api/medallion/silver/suggest', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+
+  async medallionApplySilver(body: { sourceId: string; agentId: string; buildLogId: string; config: Record<string, unknown> }) {
+    return api<MedallionLayerOut>('/api/medallion/silver/apply', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+
+  async medallionSuggestGold(body: { sourceId: string; agentId: string; feedback?: string }) {
+    return api<GoldSuggestResponse>('/api/medallion/gold/suggest', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+
+  async medallionApplyGold(body: { sourceId: string; agentId: string; buildLogId: string; selectedTables: Record<string, unknown>[] }) {
+    return api<{ layers: MedallionLayerOut[]; totalRows: number }>('/api/medallion/gold/apply', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  },
+
+  async medallionDeleteLayer(layerId: string) {
+    return api<{ ok: boolean }>(`/api/medallion/layers/${layerId}`, { method: 'DELETE' });
   },
 };


### PR DESCRIPTION
## Summary
Implements issue #107 — AI-Assisted Medallion Architecture for file-based data sources.

- **Bronze layer**: Auto-stages raw data with metadata columns (`_loaded_at`, `_source_file`, `_row_hash`)
- **Silver layer**: LLM suggests type casting, null handling, dedup; user can review, edit inline, and redo with feedback before applying
- **Gold layer**: LLM suggests business aggregates; user selects which to materialize, can redo with feedback
- **Query routing**: `ask_csv` prefers Silver/Gold tables when available for better LLM accuracy
- **All schemas and SQL stored**: Every suggestion, redo, and apply is logged in `MedallionBuildLog` and viewable in the UI

### New files
- `backend/app/models.py` — `MedallionLayer`, `MedallionBuildLog` models
- `backend/app/services/medallion_service.py` — Core logic (generate, suggest, apply)
- `backend/app/routers/medallion_router.py` — 8 API endpoints
- `backend/alembic/versions/20260407120000_add_medallion_tables.py` — Migration
- `src/components/MedallionPanel.tsx` — Full UI with Bronze/Silver/Gold tabs

### Interactive "redo with feedback" pattern
1. `POST /silver/suggest` → AI generates suggestion
2. User reviews editable table + SQL preview
3. User types feedback → `POST /silver/suggest` with `feedback` → new suggestion
4. User edits directly in form
5. `POST /silver/apply` → executes SQL

## Test plan
- [ ] Upload a CSV → Open Medallion panel from Studio
- [ ] Generate Bronze layer → verify column list and DDL
- [ ] Suggest Silver schema → edit column types → redo with feedback → apply
- [ ] Suggest Gold aggregates → select subset → redo with feedback → apply
- [ ] Ask a question → verify it routes through Silver/Gold tables
- [ ] Check Build History sidebar shows all actions
- [ ] `npm run typecheck` passes ✅
- [ ] `npm test` passes (22/22) ✅

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)