### PR TITLE
fix: make Studio panel responsive — all features fit on screen

### DIFF
--- a/src/components/StudioPanel.tsx
+++ b/src/components/StudioPanel.tsx
@@ -145,32 +145,30 @@ export function StudioPanel({ onAddNote, onOpenGraph, onOpenSummary, onOpenAudio
         </Button>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 overflow-y-auto p-3 space-y-3">
         {/* Studio Section */}
         <div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-3 gap-2">
             {studioOptions.map((option) => (
               <Card
                 key={option.title}
-                className={`p-4 cursor-pointer transition-all h-28 ${
+                className={`p-2 cursor-pointer transition-all ${
                   option.locked
                     ? "opacity-50 hover:opacity-75"
                     : "hover:shadow-md hover:border-blue-400"
                 }`}
                 onClick={option.locked ? handleLockedClick : option.onClick}
               >
-                <div className="flex flex-col items-center justify-center text-center gap-2 h-full">
+                <div className="flex flex-col items-center justify-center text-center gap-1.5 py-2">
                   <div className="relative">
-                    <option.icon className="h-8 w-8 text-muted-foreground" />
+                    <option.icon className="h-5 w-5 text-muted-foreground" />
                     {option.locked && (
                       <div className="absolute -top-1 -right-1 bg-background rounded-full p-0.5">
-                        <Lock className="h-3 w-3 text-muted-foreground" />
+                        <Lock className="h-2.5 w-2.5 text-muted-foreground" />
                       </div>
                     )}
                   </div>
-                  <div>
-                    <p className="text-sm font-semibold">{option.title}</p>
-                  </div>
+                  <p className="text-xs font-medium leading-tight">{option.title}</p>
                 </div>
               </Card>
             ))}
@@ -178,31 +176,29 @@ export function StudioPanel({ onAddNote, onOpenGraph, onOpenSummary, onOpenAudio
         </div>
 
         {/* Connections Section */}
-        <div className="border-t pt-4">
-          <h3 className="text-sm font-semibold mb-3">{t('studio.connections')}</h3>
-          <div className="grid grid-cols-2 gap-3">
+        <div className="border-t pt-3">
+          <h3 className="text-xs font-semibold mb-2 text-muted-foreground">{t('studio.connections')}</h3>
+          <div className="grid grid-cols-4 gap-2">
             {connectionOptions.map((option) => (
               <Card
                 key={option.title}
-                className={`p-4 cursor-pointer transition-all min-h-28 ${
+                className={`p-2 cursor-pointer transition-all ${
                   option.locked
                     ? "opacity-50 hover:opacity-75"
                     : "hover:shadow-md hover:border-blue-400"
                 }`}
                 onClick={option.locked ? handleLockedClick : option.onClick}
               >
-                <div className="flex flex-col items-center justify-center text-center gap-2 h-full">
+                <div className="flex flex-col items-center justify-center text-center gap-1.5 py-2">
                   <div className="relative">
-                    <option.icon className="h-8 w-8 text-muted-foreground" />
+                    <option.icon className="h-5 w-5 text-muted-foreground" />
                     {option.locked && (
                       <div className="absolute -top-1 -right-1 bg-background rounded-full p-0.5">
-                        <Lock className="h-3 w-3 text-muted-foreground" />
+                        <Lock className="h-2.5 w-2.5 text-muted-foreground" />
                       </div>
                     )}
                   </div>
-                  <div className="min-w-0 px-1">
-                    <p className="text-sm font-semibold">{option.title}</p>
-                  </div>
+                  <p className="text-xs font-medium leading-tight">{option.title}</p>
                 </div>
               </Card>
             ))}
@@ -211,14 +207,14 @@ export function StudioPanel({ onAddNote, onOpenGraph, onOpenSummary, onOpenAudio
 
       </div>
 
-      <div className="p-4 border-t">
+      <div className="p-3 border-t">
         <Button
           variant="outline"
-          className="w-full h-12 opacity-50 cursor-not-allowed"
+          className="w-full h-9 text-xs opacity-50 cursor-not-allowed"
           onClick={onAddNote}
           disabled
         >
-          <Lock className="h-4 w-4 mr-2" />
+          <Lock className="h-3.5 w-3.5 mr-1.5" />
           {t('studio.addNote')}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
Make Studio panel cards compact and responsive so all 8 studio options + 4 connections fit on screen without scrolling.

- Studio grid: 2 cols → 3 cols, cards auto-height with compact padding
- Connections grid: 2 cols → 4 cols (single row)
- Icons: 32px → 20px, text: sm → xs
- Footer button: smaller

## Test plan
- [ ] Open Studio panel → all 8 features + 4 connections visible
- [ ] No scrolling needed on standard 1080p+ screens
- [ ] Cards still clickable and hover effects work

🤖 Generated with [Claude Code](https://claude.com/claude-code)