### PR TITLE
feat: dynamic port resolution between backend and frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,9 @@ dev: setup-env
 		sleep 1; \
 	done
 	@BACKEND_PORT=$$(cat backend/.backend_port 2>/dev/null || echo 8000); \
-	echo "Backend running on port $$BACKEND_PORT"; \
-	VITE_API_URL=http://localhost:$$BACKEND_PORT npm run dev
+	echo "✅ Backend running on port $$BACKEND_PORT"; \
+	echo "🚀 Starting frontend (Vite will proxy /api → backend:$$BACKEND_PORT)..."; \
+	npm run dev
 
 # ------------------------------------------------------------------
 # Database

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,20 @@
 /**
  * Backend configuration.
- * When VITE_API_URL is set (or app is served from backend), use the Python API (no Supabase).
+ *
+ * Resolution order:
+ * 1. VITE_API_URL env variable (set by `make dev` or vite.config.ts proxy)
+ * 2. Same origin (production: frontend served from backend on same port)
+ * 3. Vite proxy fallback: in dev mode the Vite proxy forwards /api/* to the
+ *    backend, so an empty string (relative URL) works transparently.
  */
 const API_URL = import.meta.env.VITE_API_URL as string | undefined;
 
 export function getApiUrl(): string {
   const fromEnv = API_URL ? API_URL.replace(/\/$/, '') : '';
   if (fromEnv) return fromEnv;
-  // When app is served from the backend (e.g. localhost:8000), use same origin
+  // When app is served from the backend (e.g. localhost:8000), use same origin.
+  // In Vite dev mode with proxy, relative URLs ("/api/...") are proxied
+  // automatically, so returning '' is correct.
   if (typeof window !== 'undefined' && window.location?.origin) return window.location.origin;
   return '';
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,59 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import fs from "fs";
+
+/**
+ * Read the backend port from backend/.backend_port (written by the CLI
+ * when it finds an available port). Falls back to 8000 if the file
+ * doesn't exist (backend hasn't started yet or was started manually).
+ */
+function resolveBackendPort(): number {
+  const portFile = path.resolve(__dirname, "backend/.backend_port");
+  try {
+    const raw = fs.readFileSync(portFile, "utf-8").trim();
+    const port = parseInt(raw, 10);
+    if (!isNaN(port) && port > 0) return port;
+  } catch {
+    // file doesn't exist yet — use default
+  }
+  return 8000;
+}
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  server: {
-    host: "::",
-    port: 8080,
-    strictPort: false,
-  },
-  plugins: [react()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ command }) => {
+  const backendPort = resolveBackendPort();
+  const backendUrl = `http://localhost:${backendPort}`;
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
+      strictPort: false,
+      proxy: {
+        "/api": {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+        "/health": {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+      },
     },
-  },
+    plugins: [react()],
+    define: {
+      // Make the backend URL available at build time for dev mode.
+      // In production (make run), the frontend is served from the backend
+      // itself so same-origin works automatically.
+      ...(command === "serve" && !process.env.VITE_API_URL
+        ? { "import.meta.env.VITE_API_URL": JSON.stringify(backendUrl) }
+        : {}),
+    },
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
Make frontend automatically discover the backend's port via the `.backend_port` file.

- `vite.config.ts` reads `backend/.backend_port` and sets up `/api` proxy + `VITE_API_URL`
- `npm run dev` now works standalone without needing `make dev` or manual `VITE_API_URL`
- Makefile simplified: Vite reads the port itself, no need to pass env var
- Fallback to port 8000 if `.backend_port` doesn't exist

## Test plan
- [ ] `make dev` with port 8000 free → both start, frontend proxies to 8000
- [ ] `make dev` with port 8000 occupied → backend uses 8001+, frontend auto-proxies
- [ ] `npm run dev` after backend already running → reads .backend_port correctly
- [ ] `make run` (production) → same-origin works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)