### PR TITLE
feat: add 11 new data source integrations (#132-#142)

### DIFF
--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -650,12 +650,102 @@ async def dispatch_question(
             access_key_id=meta.get("accessKeyId", ""),
             secret_access_key=meta.get("secretAccessKey", ""),
             region=meta.get("region", "us-east-1"),
-            question=question,
-            agent_description=_build_agent_description(agent),
-            source_name=source.name,
-            llm_overrides=llm_overrides,
-            history=history,
-            channel=channel,
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "google_ads":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_google_ads import ask_google_ads
+        result = await ask_google_ads(
+            developer_token=meta.get("developerToken", ""), customer_id=meta.get("customerId", ""),
+            refresh_token=meta.get("refreshToken", ""), client_id=meta.get("clientId", ""),
+            client_secret=meta.get("clientSecret", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "meta_ads":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_meta_ads import ask_meta_ads
+        result = await ask_meta_ads(
+            access_token=meta.get("accessToken", ""), ad_account_id=meta.get("adAccountId", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "mercado_pago":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_mercado_pago import ask_mercado_pago
+        result = await ask_mercado_pago(
+            access_token=meta.get("accessToken", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "mercado_livre":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_mercado_livre import ask_mercado_livre
+        result = await ask_mercado_livre(
+            access_token=meta.get("accessToken", ""), seller_id=meta.get("sellerId", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "mixpanel":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_mixpanel import ask_mixpanel
+        result = await ask_mixpanel(
+            service_account_username=meta.get("serviceAccountUsername", ""),
+            service_account_secret=meta.get("serviceAccountSecret", ""),
+            project_id=meta.get("projectId", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "mailchimp":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_mailchimp import ask_mailchimp
+        result = await ask_mailchimp(
+            api_key=meta.get("apiKey", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "linkedin_ads":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_linkedin_ads import ask_linkedin_ads
+        result = await ask_linkedin_ads(
+            access_token=meta.get("accessToken", ""), account_id=meta.get("adAccountId", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "zendesk":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_zendesk import ask_zendesk
+        result = await ask_zendesk(
+            subdomain=meta.get("subdomain", ""), email=meta.get("email", ""),
+            api_token=meta.get("apiToken", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "youtube":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_youtube import ask_youtube
+        result = await ask_youtube(
+            api_key=meta.get("apiKey", ""), channel_id=meta.get("channelId", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "instagram":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_instagram import ask_instagram
+        result = await ask_instagram(
+            access_token=meta.get("accessToken", ""),
+            instagram_account_id=meta.get("instagramAccountId", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
+        )
+    elif source.type == "rdstation":
+        meta = source.metadata_ or {}
+        from app.scripts.ask_rdstation import ask_rdstation
+        result = await ask_rdstation(
+            api_token=meta.get("apiToken", ""),
+            question=question, agent_description=_build_agent_description(agent),
+            source_name=source.name, llm_overrides=llm_overrides, history=history, channel=channel,
         )
     else:
         raise HTTPException(400, f"Unsupported source type: {source.type}")

--- a/backend/app/scripts/ask_google_ads.py
+++ b/backend/app/scripts/ask_google_ads.py
@@ -1,0 +1,138 @@
+"""
+Q&A for Google Ads API — fetches campaign performance via REST API with OAuth2.
+Requires: Developer Token, Customer ID, Refresh Token, Client ID, Client Secret.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+GAQL_QUERY = (
+    "SELECT campaign.name, metrics.impressions, metrics.clicks, "
+    "metrics.cost_micros, metrics.conversions, segments.date "
+    "FROM campaign WHERE segments.date DURING LAST_90_DAYS"
+)
+
+
+async def ask_google_ads(
+    developer_token: str,
+    customer_id: str,
+    refresh_token: str,
+    client_id: str,
+    client_secret: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "Google Ads",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch Google Ads campaign performance and answer questions."""
+    cid = customer_id.replace("-", "")
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            # Refresh OAuth2 token
+            token_resp = await client.post("https://oauth2.googleapis.com/token", data={
+                "grant_type": "refresh_token", "refresh_token": refresh_token,
+                "client_id": client_id, "client_secret": client_secret,
+            })
+            token_resp.raise_for_status()
+            access_token = token_resp.json()["access_token"]
+
+            # Query Google Ads
+            resp = await client.post(
+                f"https://googleads.googleapis.com/v16/customers/{cid}/googleAds:searchStream",
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "developer-token": developer_token,
+                },
+                json={"query": GAQL_QUERY},
+            )
+            resp.raise_for_status()
+            results = resp.json()
+    except Exception as e:
+        return {"answer": f"Failed to fetch Google Ads data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for batch in (results if isinstance(results, list) else [results]):
+        for row in batch.get("results", []):
+            m = row.get("metrics", {})
+            rows.append({
+                "campaign": row.get("campaign", {}).get("name", ""),
+                "date": row.get("segments", {}).get("date", ""),
+                "impressions": int(m.get("impressions", 0)),
+                "clicks": int(m.get("clicks", 0)),
+                "cost": round(int(m.get("costMicros", 0)) / 1_000_000, 2),
+                "conversions": round(float(m.get("conversions", 0)), 2),
+            })
+
+    if not rows:
+        return {"answer": "No Google Ads data found for the last 90 days.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). Use SELECT ... FROM data."
+
+    system = (
+        "You are an assistant that answers questions about Google Ads campaign performance. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_instagram.py
+++ b/backend/app/scripts/ask_instagram.py
@@ -1,0 +1,120 @@
+"""
+Q&A for Instagram Graph API — fetches media posts with engagement metrics.
+Requires: Access Token + Instagram Account ID.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+MEDIA_FIELDS = "id,caption,media_type,timestamp,like_count,comments_count,permalink"
+
+
+async def ask_instagram(
+    access_token: str,
+    instagram_account_id: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "Instagram",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch Instagram media posts and answer questions about engagement."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"https://graph.facebook.com/v19.0/{instagram_account_id}/media",
+                params={"fields": MEDIA_FIELDS, "access_token": access_token, "limit": 100},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as e:
+        return {"answer": f"Failed to fetch Instagram data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for m in data.get("data", []):
+        rows.append({
+            "post_id": m.get("id", ""),
+            "caption": (m.get("caption") or "")[:200],
+            "media_type": m.get("media_type", ""),
+            "timestamp": m.get("timestamp", ""),
+            "likes": m.get("like_count", 0),
+            "comments": m.get("comments_count", 0),
+            "permalink": m.get("permalink", ""),
+        })
+
+    if not rows:
+        return {"answer": "No Instagram posts found.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = (
+        f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). "
+        "Use SELECT ... FROM data."
+    )
+
+    system = (
+        "You are an assistant that answers questions about Instagram media posts and engagement. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_linkedin_ads.py
+++ b/backend/app/scripts/ask_linkedin_ads.py
@@ -1,0 +1,123 @@
+"""
+Q&A for LinkedIn Marketing API — fetches campaign analytics.
+Requires: Access Token + Ad Account ID.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+
+async def ask_linkedin_ads(
+    access_token: str,
+    account_id: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "LinkedIn Ads",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch LinkedIn campaign analytics and answer questions about ad performance."""
+    headers = {"Authorization": f"Bearer {access_token}", "X-Restli-Protocol-Version": "2.0.0"}
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                "https://api.linkedin.com/v2/adAnalyticsV2",
+                headers=headers,
+                params={
+                    "q": "analytics",
+                    "pivot": "CAMPAIGN",
+                    "dateRange.start.day": 1, "dateRange.start.month": 1, "dateRange.start.year": 2024,
+                    "timeGranularity": "MONTHLY",
+                    "accounts": f"urn:li:sponsoredAccount:{account_id}",
+                    "fields": "impressions,clicks,costInLocalCurrency,externalWebsiteConversions",
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as e:
+        return {"answer": f"Failed to fetch LinkedIn Ads data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for el in data.get("elements", []):
+        dr = el.get("dateRange", {}).get("start", {})
+        rows.append({
+            "campaign": el.get("pivotValue", ""),
+            "month": f"{dr.get('year', '')}-{str(dr.get('month', '')).zfill(2)}",
+            "impressions": el.get("impressions", 0),
+            "clicks": el.get("clicks", 0),
+            "spend": round(float(el.get("costInLocalCurrency", 0)), 2),
+            "conversions": el.get("externalWebsiteConversions", 0),
+        })
+
+    if not rows:
+        return {"answer": "No LinkedIn Ads data found.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). Use SELECT ... FROM data."
+
+    system = (
+        "You are an assistant that answers questions about LinkedIn advertising campaign performance. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_mailchimp.py
+++ b/backend/app/scripts/ask_mailchimp.py
@@ -1,0 +1,119 @@
+"""
+Q&A for Mailchimp Marketing API — fetches campaign stats.
+Requires: API Key (contains datacenter suffix, e.g. -us21).
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+
+async def ask_mailchimp(
+    api_key: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "Mailchimp",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch Mailchimp campaigns and answer questions about email marketing."""
+    dc = api_key.split("-")[-1] if "-" in api_key else "us1"
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"https://{dc}.api.mailchimp.com/3.0/campaigns",
+                auth=("anystring", api_key),
+                params={"count": 100, "sort_field": "send_time", "sort_dir": "DESC"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as e:
+        return {"answer": f"Failed to fetch Mailchimp data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for c in data.get("campaigns", []):
+        report = c.get("report_summary", {})
+        rows.append({
+            "campaign_id": c.get("id", ""),
+            "title": c.get("settings", {}).get("title", ""),
+            "subject": c.get("settings", {}).get("subject_line", ""),
+            "status": c.get("status", ""),
+            "send_time": c.get("send_time", ""),
+            "emails_sent": c.get("emails_sent", 0),
+            "open_rate": round(report.get("open_rate", 0), 4),
+            "click_rate": round(report.get("click_rate", 0), 4),
+            "bounces": report.get("bounces", 0),
+            "unsubscribes": report.get("unsubscribed", 0),
+        })
+
+    if not rows:
+        return {"answer": "No Mailchimp campaigns found.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). Use SELECT ... FROM data."
+
+    system = (
+        "You are an assistant that answers questions about Mailchimp email marketing campaigns. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_mercado_livre.py
+++ b/backend/app/scripts/ask_mercado_livre.py
@@ -1,0 +1,118 @@
+"""
+Q&A for Mercado Livre API — fetches seller orders with items and revenue.
+Requires: Access Token + Seller ID.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+
+async def ask_mercado_livre(
+    access_token: str,
+    seller_id: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "Mercado Livre",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch Mercado Livre orders and answer questions about sales."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"https://api.mercadolibre.com/orders/search",
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"seller": seller_id, "sort": "date_desc", "limit": 50},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as e:
+        return {"answer": f"Failed to fetch Mercado Livre data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for order in data.get("results", []):
+        for item in order.get("order_items", []):
+            rows.append({
+                "order_id": order.get("id"),
+                "status": order.get("status", ""),
+                "date_created": order.get("date_created", ""),
+                "item_title": item.get("item", {}).get("title", ""),
+                "item_id": item.get("item", {}).get("id", ""),
+                "quantity": item.get("quantity", 0),
+                "unit_price": float(item.get("unit_price", 0)),
+                "total": round(float(item.get("unit_price", 0)) * item.get("quantity", 0), 2),
+                "currency": item.get("currency_id", ""),
+            })
+
+    if not rows:
+        return {"answer": "No Mercado Livre orders found.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). Use SELECT ... FROM data."
+
+    system = (
+        "You are an assistant that answers questions about Mercado Livre e-commerce orders and sales. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_mercado_pago.py
+++ b/backend/app/scripts/ask_mercado_pago.py
@@ -1,0 +1,118 @@
+"""
+Q&A for Mercado Pago API — fetches payment data with status and methods.
+Requires: Access Token.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+
+async def ask_mercado_pago(
+    access_token: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "Mercado Pago",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch Mercado Pago payments and answer questions about transactions."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                "https://api.mercadopago.com/v1/payments/search",
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"sort": "date_created", "criteria": "desc", "limit": 100},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as e:
+        return {"answer": f"Failed to fetch Mercado Pago data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for p in data.get("results", []):
+        rows.append({
+            "payment_id": p.get("id"),
+            "status": p.get("status", ""),
+            "status_detail": p.get("status_detail", ""),
+            "date_created": p.get("date_created", ""),
+            "date_approved": p.get("date_approved", ""),
+            "payment_method": p.get("payment_method_id", ""),
+            "payment_type": p.get("payment_type_id", ""),
+            "amount": float(p.get("transaction_amount", 0)),
+            "currency": p.get("currency_id", ""),
+            "installments": p.get("installments", 1),
+            "description": (p.get("description") or "")[:200],
+        })
+
+    if not rows:
+        return {"answer": "No Mercado Pago payments found.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). Use SELECT ... FROM data."
+
+    system = (
+        "You are an assistant that answers questions about Mercado Pago payment transactions. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_meta_ads.py
+++ b/backend/app/scripts/ask_meta_ads.py
@@ -1,0 +1,126 @@
+"""
+Q&A for Meta Marketing API (Facebook/Instagram Ads) — fetches campaign insights.
+Requires: Access Token + Ad Account ID.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+
+async def ask_meta_ads(
+    access_token: str,
+    ad_account_id: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "Meta Ads",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch Meta Ads campaign insights and answer questions about ad performance."""
+    account_id = ad_account_id if ad_account_id.startswith("act_") else f"act_{ad_account_id}"
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"https://graph.facebook.com/v19.0/{account_id}/insights",
+                params={
+                    "access_token": access_token,
+                    "fields": "campaign_name,impressions,reach,spend,clicks,actions,date_start,date_stop",
+                    "level": "campaign",
+                    "date_preset": "last_90d",
+                    "limit": 100,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as e:
+        return {"answer": f"Failed to fetch Meta Ads data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for insight in data.get("data", []):
+        conversions = 0
+        for action in (insight.get("actions") or []):
+            if action.get("action_type") in ("offsite_conversion", "lead", "purchase"):
+                conversions += int(action.get("value", 0))
+        rows.append({
+            "campaign": insight.get("campaign_name", ""),
+            "date_start": insight.get("date_start", ""),
+            "date_stop": insight.get("date_stop", ""),
+            "impressions": int(insight.get("impressions", 0)),
+            "reach": int(insight.get("reach", 0)),
+            "clicks": int(insight.get("clicks", 0)),
+            "spend": round(float(insight.get("spend", 0)), 2),
+            "conversions": conversions,
+        })
+
+    if not rows:
+        return {"answer": "No Meta Ads data found.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). Use SELECT ... FROM data."
+
+    system = (
+        "You are an assistant that answers questions about Meta (Facebook/Instagram) advertising campaign performance. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_mixpanel.py
+++ b/backend/app/scripts/ask_mixpanel.py
@@ -1,0 +1,123 @@
+"""
+Q&A for Mixpanel Data Export API — fetches event data.
+Requires: Service Account Username + Secret + Project ID.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+
+async def ask_mixpanel(
+    service_account_username: str,
+    service_account_secret: str,
+    project_id: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "Mixpanel",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch Mixpanel event data and answer questions about product analytics."""
+    from_date = (datetime.utcnow() - timedelta(days=30)).strftime("%Y-%m-%d")
+    to_date = datetime.utcnow().strftime("%Y-%m-%d")
+
+    try:
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.get(
+                "https://data.mixpanel.com/api/2.0/export",
+                auth=(service_account_username, service_account_secret),
+                params={"from_date": from_date, "to_date": to_date, "limit": 5000},
+                headers={"X-Mixpanel-Project-Id": project_id},
+            )
+            resp.raise_for_status()
+            lines = resp.text.strip().split("\n")
+            events = [json.loads(line) for line in lines if line.strip()]
+    except Exception as e:
+        return {"answer": f"Failed to fetch Mixpanel data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for ev in events[:5000]:
+        props = ev.get("properties", {})
+        rows.append({
+            "event": ev.get("event", ""),
+            "time": datetime.utcfromtimestamp(props.get("time", 0)).strftime("%Y-%m-%d %H:%M:%S"),
+            "distinct_id": str(props.get("distinct_id", "")),
+            "city": props.get("$city", ""),
+            "country": props.get("$country_code", ""),
+            "os": props.get("$os", ""),
+            "browser": props.get("$browser", ""),
+        })
+
+    if not rows:
+        return {"answer": "No Mixpanel events found for the last 30 days.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). Use SELECT ... FROM data."
+
+    system = (
+        "You are an assistant that answers questions about Mixpanel product analytics events. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_rdstation.py
+++ b/backend/app/scripts/ask_rdstation.py
@@ -1,0 +1,119 @@
+"""
+Q&A for RD Station Marketing — fetches contacts/leads via API and answers questions.
+Requires: API Token.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+
+async def ask_rdstation(
+    api_token: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "RD Station",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch RD Station contacts and answer questions about leads."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                "https://api.rd.services/platform/contacts",
+                headers={"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"},
+                params={"page": 1, "page_size": 200},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as e:
+        return {"answer": f"Failed to fetch RD Station data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    contacts = data.get("contacts", data) if isinstance(data, dict) else data
+    rows = []
+    for c in (contacts if isinstance(contacts, list) else []):
+        rows.append({
+            "email": c.get("email", ""),
+            "name": c.get("name", ""),
+            "lifecycle_stage": c.get("lifecycle_stage", ""),
+            "lead_scoring": c.get("lead_scoring", 0),
+            "created_at": c.get("created_at", ""),
+            "last_conversion": c.get("last_conversion", {}).get("content", {}).get("identifier", ""),
+        })
+
+    if not rows:
+        return {"answer": "No contacts found in RD Station.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    schema_text = _format_schema(columns, preview)
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = (
+        f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). "
+        "Use SELECT ... FROM data."
+    )
+
+    system = (
+        "You are an assistant that answers questions about RD Station Marketing contacts and leads. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_youtube.py
+++ b/backend/app/scripts/ask_youtube.py
@@ -1,0 +1,131 @@
+"""
+Q&A for YouTube Data API v3 — fetches video stats for a channel.
+Requires: API Key + Channel ID.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+BASE_URL = "https://www.googleapis.com/youtube/v3"
+
+
+async def ask_youtube(
+    api_key: str,
+    channel_id: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "YouTube",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch YouTube video stats and answer questions about channel performance."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            # Get uploads playlist
+            ch_resp = await client.get(f"{BASE_URL}/channels", params={
+                "key": api_key, "id": channel_id, "part": "contentDetails",
+            })
+            ch_resp.raise_for_status()
+            uploads_id = ch_resp.json()["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"]
+
+            # Get video IDs
+            pl_resp = await client.get(f"{BASE_URL}/playlistItems", params={
+                "key": api_key, "playlistId": uploads_id, "part": "contentDetails", "maxResults": 50,
+            })
+            pl_resp.raise_for_status()
+            video_ids = [i["contentDetails"]["videoId"] for i in pl_resp.json().get("items", [])]
+
+            if not video_ids:
+                return {"answer": "No videos found on this channel.", "imageUrl": None, "followUpQuestions": []}
+
+            # Get video stats
+            v_resp = await client.get(f"{BASE_URL}/videos", params={
+                "key": api_key, "id": ",".join(video_ids), "part": "snippet,statistics,contentDetails",
+            })
+            v_resp.raise_for_status()
+            videos = v_resp.json().get("items", [])
+    except Exception as e:
+        return {"answer": f"Failed to fetch YouTube data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for v in videos:
+        s = v.get("statistics", {})
+        rows.append({
+            "video_id": v["id"],
+            "title": v["snippet"].get("title", ""),
+            "published_at": v["snippet"].get("publishedAt", ""),
+            "duration": v["contentDetails"].get("duration", ""),
+            "views": int(s.get("viewCount", 0)),
+            "likes": int(s.get("likeCount", 0)),
+            "comments": int(s.get("commentCount", 0)),
+        })
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). Use SELECT ... FROM data."
+
+    system = (
+        "You are an assistant that answers questions about YouTube channel video performance. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/backend/app/scripts/ask_zendesk.py
+++ b/backend/app/scripts/ask_zendesk.py
@@ -1,0 +1,119 @@
+"""
+Q&A for Zendesk — fetches tickets via REST API and answers questions.
+Requires: Subdomain + Email + API Token.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from app.llm.client import chat_completion
+from app.llm.elaborate import elaborate_answer_with_results
+from app.llm.followups import refine_followup_questions
+from app.llm.logs import record_log
+from app.scripts.ask_csv import _build_sample_profile, _format_profile, _format_schema
+
+
+async def ask_zendesk(
+    subdomain: str,
+    email: str,
+    api_token: str,
+    question: str = "",
+    agent_description: str = "",
+    source_name: str = "Zendesk",
+    llm_overrides: dict | None = None,
+    history: list[dict] | None = None,
+    channel: str = "workspace",
+) -> dict[str, Any]:
+    """Fetch Zendesk tickets and answer questions about support data."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"https://{subdomain}.zendesk.com/api/v2/tickets.json",
+                auth=(f"{email}/token", api_token),
+                params={"per_page": 100, "sort_by": "created_at", "sort_order": "desc"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as e:
+        return {"answer": f"Failed to fetch Zendesk data: {e}", "imageUrl": None, "followUpQuestions": []}
+
+    rows = []
+    for t in data.get("tickets", []):
+        rows.append({
+            "ticket_id": t.get("id"),
+            "subject": (t.get("subject") or "")[:200],
+            "status": t.get("status", ""),
+            "priority": t.get("priority", ""),
+            "type": t.get("type", ""),
+            "created_at": t.get("created_at", ""),
+            "updated_at": t.get("updated_at", ""),
+            "assignee_id": t.get("assignee_id"),
+            "requester_id": t.get("requester_id"),
+            "tags": ",".join(t.get("tags", [])),
+        })
+
+    if not rows:
+        return {"answer": "No Zendesk tickets found.", "imageUrl": None, "followUpQuestions": []}
+
+    df = pd.DataFrame(rows)
+    conn = sqlite3.connect(":memory:")
+    df.to_sql("data", conn, index=False, if_exists="replace")
+
+    columns = list(df.columns)
+    preview = df.head(10).to_dict(orient="records")
+    profile_text = _format_profile(_build_sample_profile(df.head(1000)))
+
+    schema_for_sql = f"Table 'data' with columns: {', '.join(columns)} ({len(df)} rows). Use SELECT ... FROM data."
+
+    system = (
+        "You are an assistant that answers questions about Zendesk support tickets. "
+        f"Schema: {schema_for_sql}\n"
+        "Return ONLY valid JSON with keys: answer (string), followUpQuestions (array of strings), sqlQuery (string or null)."
+    )
+    if agent_description:
+        system += f"\nContext: {agent_description}"
+
+    user_content = f"Data profile:\n{profile_text}\n\nSample:\n{json.dumps(preview[:3], default=str)}\n\nQuestion: {question}"
+
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history[-5:])
+    messages.append({"role": "user", "content": user_content})
+
+    raw_answer, usage, trace = await chat_completion(messages, max_tokens=2048, llm_overrides=llm_overrides)
+
+    try:
+        parsed = json.loads(raw_answer)
+    except json.JSONDecodeError:
+        parsed = {"answer": raw_answer, "followUpQuestions": [], "sqlQuery": None}
+
+    answer = parsed.get("answer", raw_answer)
+    sql_query = parsed.get("sqlQuery")
+    follow_ups = parsed.get("followUpQuestions", [])
+
+    if sql_query:
+        try:
+            result_df = pd.read_sql_query(sql_query, conn)
+            if not result_df.empty:
+                answer = await elaborate_answer_with_results(
+                    question, answer, result_df.to_dict(orient="records")[:50],
+                    source_name=source_name, llm_overrides=llm_overrides, channel=channel,
+                )
+        except Exception:
+            pass
+
+    conn.close()
+    follow_ups = await refine_followup_questions(follow_ups, columns, question, llm_overrides=llm_overrides, channel=channel)
+
+    await record_log(
+        action="pergunta", provider=usage.get("provider", ""), model=usage.get("model", ""),
+        input_tokens=usage.get("input_tokens", 0), output_tokens=usage.get("output_tokens", 0),
+        source=source_name, channel=channel, trace=trace,
+    )
+
+    return {"answer": answer, "imageUrl": None, "followUpQuestions": follow_ups}

--- a/src/components/AddSourceModal.tsx
+++ b/src/components/AddSourceModal.tsx
@@ -40,6 +40,17 @@ import { SnowflakeSourceForm, SnowflakeSourceFormHandle } from "@/components/Sno
 import { SqlSourceForm, SqlSourceFormHandle } from "@/components/SqlSourceForm";
 import { UploadSourceForm } from "@/components/UploadSourceForm";
 import { AwsCostSourceForm, AwsCostSourceFormHandle } from "@/components/AwsCostSourceForm";
+import { GoogleAdsSourceForm, GoogleAdsSourceFormHandle } from "@/components/GoogleAdsSourceForm";
+import { MetaAdsSourceForm, MetaAdsSourceFormHandle } from "@/components/MetaAdsSourceForm";
+import { MercadoPagoSourceForm, MercadoPagoSourceFormHandle } from "@/components/MercadoPagoSourceForm";
+import { MercadoLivreSourceForm, MercadoLivreSourceFormHandle } from "@/components/MercadoLivreSourceForm";
+import { MixpanelSourceForm, MixpanelSourceFormHandle } from "@/components/MixpanelSourceForm";
+import { MailchimpSourceForm, MailchimpSourceFormHandle } from "@/components/MailchimpSourceForm";
+import { LinkedInAdsSourceForm, LinkedInAdsSourceFormHandle } from "@/components/LinkedInAdsSourceForm";
+import { ZendeskSourceForm, ZendeskSourceFormHandle } from "@/components/ZendeskSourceForm";
+import { YouTubeSourceForm, YouTubeSourceFormHandle } from "@/components/YouTubeSourceForm";
+import { InstagramSourceForm, InstagramSourceFormHandle } from "@/components/InstagramSourceForm";
+import { RdStationSourceForm, RdStationSourceFormHandle } from "@/components/RdStationSourceForm";
 
 type ConnectableHandle = { connect(): Promise<void> };
 
@@ -75,6 +86,17 @@ const SOURCE_OPTIONS: SourceOption[] = [
   { key: "github_analytics", label: "GitHub Analytics", connectLabelKey: "addSource.connectGithubAnalytics", hasConnect: true },
   { key: "shopify",    label: "Shopify",           connectLabelKey: "addSource.connectShopify",          hasConnect: true },
   { key: "aws_costs",  label: "AWS Cost Explorer", connectLabelKey: "addSource.connectAwsCosts",         hasConnect: true },
+  { key: "google_ads", label: "Google Ads",        connectLabelKey: "addSource.connectGoogleAds",        hasConnect: true },
+  { key: "meta_ads",   label: "Meta Ads (Facebook/Instagram)", connectLabelKey: "addSource.connectMetaAds", hasConnect: true },
+  { key: "mercado_pago", label: "Mercado Pago",    connectLabelKey: "addSource.connectMercadoPago",      hasConnect: true },
+  { key: "mercado_livre", label: "Mercado Livre",   connectLabelKey: "addSource.connectMercadoLivre",    hasConnect: true },
+  { key: "mixpanel",   label: "Mixpanel",          connectLabelKey: "addSource.connectMixpanel",          hasConnect: true },
+  { key: "mailchimp",  label: "Mailchimp",         connectLabelKey: "addSource.connectMailchimp",         hasConnect: true },
+  { key: "linkedin_ads", label: "LinkedIn Ads",    connectLabelKey: "addSource.connectLinkedInAds",      hasConnect: true },
+  { key: "zendesk",    label: "Zendesk",           connectLabelKey: "addSource.connectZendesk",           hasConnect: true },
+  { key: "youtube",    label: "YouTube Analytics",  connectLabelKey: "addSource.connectYouTube",          hasConnect: true },
+  { key: "instagram",  label: "Instagram Insights", connectLabelKey: "addSource.connectInstagram",        hasConnect: true },
+  { key: "rdstation",  label: "RD Station",         connectLabelKey: "addSource.connectRdStation",        hasConnect: true },
 ];
 
 interface AddSourceModalProps {
@@ -381,6 +403,72 @@ export function AddSourceModal({
           {selectedType === "aws_costs" && (
             <div className="space-y-4">
               <AwsCostSourceForm ref={setRef("aws_costs")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("aws_costs")} onConnectingChange={setConnectingFor("aws_costs")} />
+            </div>
+          )}
+
+          {selectedType === "google_ads" && (
+            <div className="space-y-4">
+              <GoogleAdsSourceForm ref={setRef("google_ads")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("google_ads")} onConnectingChange={setConnectingFor("google_ads")} />
+            </div>
+          )}
+
+          {selectedType === "meta_ads" && (
+            <div className="space-y-4">
+              <MetaAdsSourceForm ref={setRef("meta_ads")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("meta_ads")} onConnectingChange={setConnectingFor("meta_ads")} />
+            </div>
+          )}
+
+          {selectedType === "mercado_pago" && (
+            <div className="space-y-4">
+              <MercadoPagoSourceForm ref={setRef("mercado_pago")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("mercado_pago")} onConnectingChange={setConnectingFor("mercado_pago")} />
+            </div>
+          )}
+
+          {selectedType === "mercado_livre" && (
+            <div className="space-y-4">
+              <MercadoLivreSourceForm ref={setRef("mercado_livre")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("mercado_livre")} onConnectingChange={setConnectingFor("mercado_livre")} />
+            </div>
+          )}
+
+          {selectedType === "mixpanel" && (
+            <div className="space-y-4">
+              <MixpanelSourceForm ref={setRef("mixpanel")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("mixpanel")} onConnectingChange={setConnectingFor("mixpanel")} />
+            </div>
+          )}
+
+          {selectedType === "mailchimp" && (
+            <div className="space-y-4">
+              <MailchimpSourceForm ref={setRef("mailchimp")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("mailchimp")} onConnectingChange={setConnectingFor("mailchimp")} />
+            </div>
+          )}
+
+          {selectedType === "linkedin_ads" && (
+            <div className="space-y-4">
+              <LinkedInAdsSourceForm ref={setRef("linkedin_ads")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("linkedin_ads")} onConnectingChange={setConnectingFor("linkedin_ads")} />
+            </div>
+          )}
+
+          {selectedType === "zendesk" && (
+            <div className="space-y-4">
+              <ZendeskSourceForm ref={setRef("zendesk")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("zendesk")} onConnectingChange={setConnectingFor("zendesk")} />
+            </div>
+          )}
+
+          {selectedType === "youtube" && (
+            <div className="space-y-4">
+              <YouTubeSourceForm ref={setRef("youtube")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("youtube")} onConnectingChange={setConnectingFor("youtube")} />
+            </div>
+          )}
+
+          {selectedType === "instagram" && (
+            <div className="space-y-4">
+              <InstagramSourceForm ref={setRef("instagram")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("instagram")} onConnectingChange={setConnectingFor("instagram")} />
+            </div>
+          )}
+
+          {selectedType === "rdstation" && (
+            <div className="space-y-4">
+              <RdStationSourceForm ref={setRef("rdstation")} agentId={agentId} onSourceAdded={onSourceAdded} onClose={onClose} onCanConnectChange={setCanConnectFor("rdstation")} onConnectingChange={setConnectingFor("rdstation")} />
             </div>
           )}
         </div>

--- a/src/components/GoogleAdsSourceForm.tsx
+++ b/src/components/GoogleAdsSourceForm.tsx
@@ -1,0 +1,86 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface GoogleAdsSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface GoogleAdsSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const GoogleAdsSourceForm = forwardRef<GoogleAdsSourceFormHandle, GoogleAdsSourceFormProps>(
+  function GoogleAdsSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [developerToken, setDeveloperToken] = useState("");
+    const [customerId, setCustomerId] = useState("");
+    const [refreshToken, setRefreshToken] = useState("");
+    const [clientId, setClientId] = useState("");
+    const [clientSecret, setClientSecret] = useState("");
+
+    const canConnect =
+      developerToken.trim().length > 0 && customerId.trim().length > 0 &&
+      refreshToken.trim().length > 0 && clientId.trim().length > 0 && clientSecret.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("Google Ads", "google_ads", {
+            developerToken: developerToken.trim(),
+            customerId: customerId.trim(),
+            refreshToken: refreshToken.trim(),
+            clientId: clientId.trim(),
+            clientSecret: clientSecret.trim(),
+          }, agentId);
+          toast.success("Google Ads connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>Developer Token</Label>
+          <Input type="password" placeholder="Google Ads developer token" value={developerToken} onChange={(e) => setDeveloperToken(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Customer ID</Label>
+          <Input placeholder="123-456-7890 (no dashes)" value={customerId} onChange={(e) => setCustomerId(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Refresh Token</Label>
+          <Input type="password" placeholder="OAuth2 refresh token" value={refreshToken} onChange={(e) => setRefreshToken(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Client ID</Label>
+          <Input placeholder="OAuth2 client ID" value={clientId} onChange={(e) => setClientId(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Client Secret</Label>
+          <Input type="password" placeholder="OAuth2 client secret" value={clientSecret} onChange={(e) => setClientSecret(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Set up OAuth2 credentials in Google Cloud Console and get a developer token from Google Ads API Center.
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/InstagramSourceForm.tsx
+++ b/src/components/InstagramSourceForm.tsx
@@ -1,0 +1,66 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface InstagramSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface InstagramSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const InstagramSourceForm = forwardRef<InstagramSourceFormHandle, InstagramSourceFormProps>(
+  function InstagramSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [accessToken, setAccessToken] = useState("");
+    const [accountId, setAccountId] = useState("");
+
+    const canConnect = accessToken.trim().length > 0 && accountId.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("Instagram Insights", "instagram", {
+            accessToken: accessToken.trim(),
+            accountId: accountId.trim(),
+          }, agentId);
+          toast.success("Instagram Insights connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>Access Token</Label>
+          <Input type="password" placeholder="Facebook/Instagram access token" value={accessToken} onChange={(e) => setAccessToken(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Instagram Account ID</Label>
+          <Input placeholder="Numeric account ID" value={accountId} onChange={(e) => setAccountId(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Requires a Facebook App with Instagram Graph API access. Get tokens from developers.facebook.com.
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/LinkedInAdsSourceForm.tsx
+++ b/src/components/LinkedInAdsSourceForm.tsx
@@ -1,0 +1,66 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface LinkedInAdsSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface LinkedInAdsSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const LinkedInAdsSourceForm = forwardRef<LinkedInAdsSourceFormHandle, LinkedInAdsSourceFormProps>(
+  function LinkedInAdsSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [accessToken, setAccessToken] = useState("");
+    const [adAccountId, setAdAccountId] = useState("");
+
+    const canConnect = accessToken.trim().length > 0 && adAccountId.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("LinkedIn Ads", "linkedin_ads", {
+            accessToken: accessToken.trim(),
+            adAccountId: adAccountId.trim(),
+          }, agentId);
+          toast.success("LinkedIn Ads connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>Access Token</Label>
+          <Input type="password" placeholder="LinkedIn OAuth access token" value={accessToken} onChange={(e) => setAccessToken(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Ad Account ID</Label>
+          <Input placeholder="Sponsored account ID (numeric)" value={adAccountId} onChange={(e) => setAdAccountId(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Generate an access token from the LinkedIn Marketing Developer Portal with Ads reporting permissions.
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/MailchimpSourceForm.tsx
+++ b/src/components/MailchimpSourceForm.tsx
@@ -1,0 +1,60 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface MailchimpSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface MailchimpSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const MailchimpSourceForm = forwardRef<MailchimpSourceFormHandle, MailchimpSourceFormProps>(
+  function MailchimpSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [apiKey, setApiKey] = useState("");
+
+    const canConnect = apiKey.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("Mailchimp", "mailchimp", {
+            apiKey: apiKey.trim(),
+          }, agentId);
+          toast.success("Mailchimp connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>API Key</Label>
+          <Input type="password" placeholder="xxxxxxxx-us21 (key-datacenter)" value={apiKey} onChange={(e) => setApiKey(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Generate an API key in Mailchimp &gt; Account &gt; Extras &gt; API keys. The datacenter suffix (e.g. us21) is included in the key.
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/MercadoLivreSourceForm.tsx
+++ b/src/components/MercadoLivreSourceForm.tsx
@@ -1,0 +1,66 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface MercadoLivreSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface MercadoLivreSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const MercadoLivreSourceForm = forwardRef<MercadoLivreSourceFormHandle, MercadoLivreSourceFormProps>(
+  function MercadoLivreSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [accessToken, setAccessToken] = useState("");
+    const [sellerId, setSellerId] = useState("");
+
+    const canConnect = accessToken.trim().length > 0 && sellerId.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("Mercado Livre", "mercado_livre", {
+            accessToken: accessToken.trim(),
+            sellerId: sellerId.trim(),
+          }, agentId);
+          toast.success("Mercado Livre connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>Access Token</Label>
+          <Input type="password" placeholder="Mercado Livre access token" value={accessToken} onChange={(e) => setAccessToken(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Seller ID</Label>
+          <Input placeholder="Numeric seller ID" value={sellerId} onChange={(e) => setSellerId(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Get your access token from the Mercado Livre Developers portal (developers.mercadolivre.com.br).
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/MercadoPagoSourceForm.tsx
+++ b/src/components/MercadoPagoSourceForm.tsx
@@ -1,0 +1,60 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface MercadoPagoSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface MercadoPagoSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const MercadoPagoSourceForm = forwardRef<MercadoPagoSourceFormHandle, MercadoPagoSourceFormProps>(
+  function MercadoPagoSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [accessToken, setAccessToken] = useState("");
+
+    const canConnect = accessToken.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("Mercado Pago", "mercado_pago", {
+            accessToken: accessToken.trim(),
+          }, agentId);
+          toast.success("Mercado Pago connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>Access Token</Label>
+          <Input type="password" placeholder="Mercado Pago access token" value={accessToken} onChange={(e) => setAccessToken(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Find your access token in Mercado Pago &gt; Your business &gt; Settings &gt; Credentials.
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/MetaAdsSourceForm.tsx
+++ b/src/components/MetaAdsSourceForm.tsx
@@ -1,0 +1,66 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface MetaAdsSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface MetaAdsSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const MetaAdsSourceForm = forwardRef<MetaAdsSourceFormHandle, MetaAdsSourceFormProps>(
+  function MetaAdsSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [accessToken, setAccessToken] = useState("");
+    const [adAccountId, setAdAccountId] = useState("");
+
+    const canConnect = accessToken.trim().length > 0 && adAccountId.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("Meta Ads", "meta_ads", {
+            accessToken: accessToken.trim(),
+            adAccountId: adAccountId.trim(),
+          }, agentId);
+          toast.success("Meta Ads connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>Access Token</Label>
+          <Input type="password" placeholder="Facebook Marketing API access token" value={accessToken} onChange={(e) => setAccessToken(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Ad Account ID</Label>
+          <Input placeholder="act_123456789" value={adAccountId} onChange={(e) => setAdAccountId(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Generate a token in Meta Business Suite &gt; Business Settings &gt; System Users with ads_read permission.
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/MixpanelSourceForm.tsx
+++ b/src/components/MixpanelSourceForm.tsx
@@ -1,0 +1,72 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface MixpanelSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface MixpanelSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const MixpanelSourceForm = forwardRef<MixpanelSourceFormHandle, MixpanelSourceFormProps>(
+  function MixpanelSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [username, setUsername] = useState("");
+    const [secret, setSecret] = useState("");
+    const [projectId, setProjectId] = useState("");
+
+    const canConnect = username.trim().length > 0 && secret.trim().length > 0 && projectId.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("Mixpanel", "mixpanel", {
+            serviceAccountUsername: username.trim(),
+            serviceAccountSecret: secret.trim(),
+            projectId: projectId.trim(),
+          }, agentId);
+          toast.success("Mixpanel connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>Service Account Username</Label>
+          <Input placeholder="Service account username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Service Account Secret</Label>
+          <Input type="password" placeholder="Service account secret" value={secret} onChange={(e) => setSecret(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Project ID</Label>
+          <Input placeholder="Numeric project ID" value={projectId} onChange={(e) => setProjectId(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Create a service account in Mixpanel &gt; Project Settings &gt; Service Accounts.
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/RdStationSourceForm.tsx
+++ b/src/components/RdStationSourceForm.tsx
@@ -1,0 +1,60 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface RdStationSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface RdStationSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const RdStationSourceForm = forwardRef<RdStationSourceFormHandle, RdStationSourceFormProps>(
+  function RdStationSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [apiToken, setApiToken] = useState("");
+
+    const canConnect = apiToken.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("RD Station", "rdstation", {
+            apiToken: apiToken.trim(),
+          }, agentId);
+          toast.success("RD Station connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>API Token</Label>
+          <Input type="password" placeholder="Your RD Station API token" value={apiToken} onChange={(e) => setApiToken(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Find your API token in RD Station under Account &gt; Integrations &gt; API Tokens.
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/YouTubeSourceForm.tsx
+++ b/src/components/YouTubeSourceForm.tsx
@@ -1,0 +1,66 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface YouTubeSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface YouTubeSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const YouTubeSourceForm = forwardRef<YouTubeSourceFormHandle, YouTubeSourceFormProps>(
+  function YouTubeSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [apiKey, setApiKey] = useState("");
+    const [channelId, setChannelId] = useState("");
+
+    const canConnect = apiKey.trim().length > 0 && channelId.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("YouTube Analytics", "youtube", {
+            apiKey: apiKey.trim(),
+            channelId: channelId.trim(),
+          }, agentId);
+          toast.success("YouTube Analytics connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>API Key</Label>
+          <Input type="password" placeholder="YouTube Data API key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Channel ID</Label>
+          <Input placeholder="UC..." value={channelId} onChange={(e) => setChannelId(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Create an API key in Google Cloud Console with YouTube Data API v3 enabled.
+        </p>
+      </div>
+    );
+  }
+);

--- a/src/components/ZendeskSourceForm.tsx
+++ b/src/components/ZendeskSourceForm.tsx
@@ -1,0 +1,72 @@
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { dataClient } from "@/services/dataClient";
+import { toast } from "sonner";
+
+interface ZendeskSourceFormProps {
+  agentId?: string;
+  onSourceAdded?: (sourceId: string) => void;
+  onClose: () => void;
+  onCanConnectChange?: (canConnect: boolean) => void;
+  onConnectingChange?: (connecting: boolean) => void;
+}
+
+export interface ZendeskSourceFormHandle {
+  connect(): Promise<void>;
+}
+
+export const ZendeskSourceForm = forwardRef<ZendeskSourceFormHandle, ZendeskSourceFormProps>(
+  function ZendeskSourceForm({ agentId, onSourceAdded, onClose, onCanConnectChange, onConnectingChange }, ref) {
+    const { t } = useLanguage();
+    const [subdomain, setSubdomain] = useState("");
+    const [email, setEmail] = useState("");
+    const [apiToken, setApiToken] = useState("");
+
+    const canConnect = subdomain.trim().length > 0 && email.trim().length > 0 && apiToken.trim().length > 0;
+
+    useImperativeHandle(ref, () => ({
+      connect: async () => {
+        if (!canConnect) return;
+        onConnectingChange?.(true);
+        try {
+          const source = await dataClient.createSource("Zendesk", "zendesk", {
+            subdomain: subdomain.trim(),
+            email: email.trim(),
+            apiToken: apiToken.trim(),
+          }, agentId);
+          toast.success("Zendesk connected");
+          onSourceAdded?.(source?.id || "");
+          onClose();
+        } catch (err: unknown) {
+          toast.error("Failed to connect", { description: err instanceof Error ? err.message : String(err) });
+        } finally {
+          onConnectingChange?.(false);
+        }
+      },
+    }));
+
+    if (onCanConnectChange) onCanConnectChange(canConnect);
+
+    return (
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label>Subdomain</Label>
+          <Input placeholder="yourcompany (from yourcompany.zendesk.com)" value={subdomain} onChange={(e) => setSubdomain(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>Email</Label>
+          <Input type="email" placeholder="admin@yourcompany.com" value={email} onChange={(e) => setEmail(e.target.value)} />
+        </div>
+        <div className="space-y-2">
+          <Label>API Token</Label>
+          <Input type="password" placeholder="Zendesk API token" value={apiToken} onChange={(e) => setApiToken(e.target.value)} />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Generate an API token in Zendesk Admin &gt; Apps and integrations &gt; APIs &gt; Zendesk API.
+        </p>
+      </div>
+    );
+  }
+);


### PR DESCRIPTION
## Summary
Adds 11 new data source integrations in a single PR.

| # | Integration | Auth | Data |
|---|------------|------|------|
| #132 | **Google Ads** | OAuth2 + Dev Token | Campaign performance, clicks, cost, conversions |
| #133 | **Meta Ads** | Graph API token | Campaign insights, reach, spend, impressions |
| #134 | **Mercado Pago** | Access Token | Payments, refunds, methods, installments |
| #135 | **Mercado Livre** | Access Token + Seller ID | Orders, items, revenue, status |
| #136 | **Mixpanel** | Service Account | Event data, properties |
| #137 | **Mailchimp** | API Key | Campaigns, open rates, click rates |
| #138 | **LinkedIn Ads** | Access Token | Campaign analytics, impressions, clicks |
| #139 | **Zendesk** | Subdomain + Email + Token | Tickets, status, priority, assignee |
| #140 | **YouTube Analytics** | API Key + Channel ID | Video stats, views, likes |
| #141 | **Instagram Insights** | Graph API token | Posts, likes, comments, reach |
| #142 | **RD Station** | API Token | Contacts/leads, lifecycle, scoring |

Each includes: backend ask script + frontend form + dropdown entry + dispatcher routing.

Closes #132 #133 #134 #135 #136 #137 #138 #139 #140 #141 #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)