### PR TITLE
Multi-tenant security: encryption, MCP, tests, frontend (part 2 of #227)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,17 +87,21 @@ cd backend && pytest
 - React Query for server state; avoid manual fetch + useState patterns.
 
 ### Backend
-- Routers use `Depends(require_user)` for auth-protected endpoints.
+- Endpoints that touch tenant-scoped models (Source, Agent, PipelineRun, …) use `Depends(require_membership)` to resolve a `TenantScope` (user + organization_id + role), then filter every query with `tenant_filter(Model, scope)`.
+- Write/delete endpoints add `Depends(require_role("member"))` / `Depends(require_role("admin"))`.
+- User-personal endpoints (LlmConfig, QA sessions, dashboards) still use `Depends(require_user)`.
 - Database sessions injected via `Depends(get_db)`.
 - Source-specific Q&A logic lives in `app/scripts/ask_<type>.py`.
 - LLM calls go through `app/llm/client.py` (never call OpenAI SDK directly).
 - All DB operations are async (use `await` with SQLAlchemy async session).
+- Secrets in `Source.metadata_` and Telegram/WhatsApp/Slack bot tokens are Fernet-encrypted at rest; see `app/services/crypto.py`.
 - New tables/columns require an Alembic migration.
 
 ### Database
 - IDs are UUID v4 strings (not auto-increment integers).
-- Guest mode uses fixed `GUEST_USER_ID`; admin uses `ADMIN_USER_ID`.
-- Multi-tenancy via `organization_id` field on most models.
+- Guest mode uses fixed `GUEST_USER_ID`; admin uses `ADMIN_USER_ID`. The guest user is auto-enrolled as `owner` of a single `Guest` organization.
+- Multi-tenancy: `Organization` + `OrganizationMembership` drive the active-tenant scope. A User may belong to N Orgs; the active one travels in the JWT `org_id` claim or is bound to the ApiKey row.
+- Role hierarchy (ascending): `viewer < member < admin < owner`. `require_role("admin")` lets admins + owners through.
 
 ### Git & PRs
 - Keep commits focused and descriptive.
@@ -109,16 +113,31 @@ cd backend && pytest
 Backend config lives in `backend/.env`. Key variables:
 - `LLM_PROVIDER`: `openai` | `ollama` | `litellm`
 - `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_BASE_URL`
-- `SECRET_KEY`: JWT signing key
-- `ENABLE_LOGIN`: `true` enables multi-user auth; `false` (default) is guest mode
+- `SECRET_KEY`: JWT signing key. Also seeds the Fernet key used to encrypt secrets at rest, via HKDF.
+- `ENABLE_LOGIN`: `true` enables multi-user auth; `false` (default) is guest mode.
+- `GITHUB_TOKEN_ENCRYPTION_KEY`: optional explicit Fernet key (url-safe base64, 32 bytes). Overrides the HKDF derivation from `SECRET_KEY`. Set this if you need the encryption key to be independent of your JWT key (e.g., rotate JWT without re-encrypting every secret).
 - `DATABASE_URL`: Override default SQLite (e.g., PostgreSQL connection string)
 - `SMTP_*`: Email configuration for alerts and reports
 
-## Authentication Modes
+## Authentication & Multi-Tenancy
 
-1. **Guest mode** (`ENABLE_LOGIN=false`): No login screen, single shared user.
-2. **Login mode** (`ENABLE_LOGIN=true`): JWT auth, admin + regular user roles, user isolation via organization_id.
-3. **API key auth**: `X-API-Key` header for the public `POST /api/v1/ask` endpoint.
+### Modes
+1. **Guest mode** (`ENABLE_LOGIN=false`): No login screen; one guest user is auto-enrolled as `owner` of a single `Guest` organization. Every query still runs through the tenant scope, so the same security invariants hold even in dev.
+2. **Login mode** (`ENABLE_LOGIN=true`): JWT auth. `POST /auth/login` returns `{access_token, user, organizations, active_organization_id}`. The JWT carries an `org_id` claim identifying the active tenant. Users switch orgs via `POST /auth/switch-org` which issues a new token.
+3. **API key auth**: `X-API-Key` header for programmatic access. Each key is tenant-bound (`ApiKey.organization_id NOT NULL`) so it resolves to exactly one organization. MCP tool calls always require an API key — there is no guest fallback on `/mcp`.
+
+### Roles
+- `owner` — full control including future org membership management
+- `admin` — can delete tenant-scoped resources
+- `member` — can create/edit
+- `viewer` — read-only
+
+Role is per-`OrganizationMembership`, so the same user may be `admin` in org A and `viewer` in org B.
+
+### Encryption at rest
+- `Source.metadata_` secret fields (`password`, `api_key`, `service_account_json`, `connection_string`, `bearer_token`, …) are Fernet-wrapped as `{"__enc": "<cipher>"}` envelopes before persisting. Scripts and routers call `unlock_source_metadata(source)` or `decrypt_secret_fields()` transparently; API responses use `mask_secret_fields()` to never echo plaintext.
+- Telegram/WhatsApp/Slack bot tokens + Slack client/signing secrets are wrapped via the `EncryptedText` SQLAlchemy type, so `cfg.bot_token` is always plaintext in Python but encrypted in the DB.
+- GitHub OAuth access/refresh tokens are encrypted via the same Fernet key (see `app/services/github_oauth.py`).
 
 ## Testing
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -59,17 +59,25 @@ Summary scripts follow the pattern `summary_<type>.py`.
 
 - All IDs are UUID v4 strings (generated with `uuid.uuid4()`).
 - Async operations only: use `await session.execute(...)`, never synchronous calls.
-- Multi-tenancy: most models have `organization_id` for user isolation.
-- Fixed IDs: `GUEST_USER_ID` and `ADMIN_USER_ID` constants in `models.py`.
-- Source metadata (connection strings, file paths, credentials) stored as JSON in `Source.metadata_` column.
+- Multi-tenancy: `Organization` + `OrganizationMembership` (N-to-N). Tenant-scoped models carry `organization_id NOT NULL`. `User.organization_id` is an optional "last active" hint, not the authoritative scope.
+- Fixed IDs: `GUEST_USER_ID` and `ADMIN_USER_ID` constants in `models.py`. The guest user is auto-enrolled as `owner` of a `Guest` org on migration.
+- Tenant scope resolution (see `app/auth.py:require_membership`): `X-API-Key` → key's `organization_id`; otherwise JWT `org_id` claim; else guest fallback.
+- Role hierarchy: `viewer (0) < member (1) < admin (2) < owner (3)`. Use `Depends(require_role("admin"))` when writes should be restricted.
+- Secrets in `Source.metadata_` and bot tokens are Fernet-encrypted at rest; `app/services/crypto.py` provides `encrypt_secret_fields`, `unlock_source_metadata`, and the `EncryptedText` SQLAlchemy type.
 
 ## Adding New Features
 
-### New API endpoint
+### New API endpoint on a tenant-scoped model
 1. Create or extend a router in `app/routers/`.
 2. Add Pydantic schemas in `app/schemas.py`.
 3. Register the router in `app/main.py` if it's a new file.
-4. Protect with `Depends(require_user)` or `Depends(require_admin)`.
+4. Protect with `Depends(require_membership)` (read) or `Depends(require_role("member"/"admin"))` (write/delete).
+5. Filter every SELECT/UPDATE/DELETE with `tenant_filter(Model, scope)` from `app.services.tenant_scope`.
+6. On INSERT, set `organization_id=scope.organization_id`.
+
+### New API endpoint on a user-personal model (LlmConfig, QASession, ...)
+1. Keep `Depends(require_user)` + `Model.user_id == user.id` filters.
+2. Do not use `tenant_filter` — it raises if the model has no `organization_id` column.
 
 ### New data source type
 1. Create `app/scripts/ask_<type>.py` following the pattern of existing scripts.

--- a/backend/alembic/versions/20260413130000_encrypt_existing_secrets.py
+++ b/backend/alembic/versions/20260413130000_encrypt_existing_secrets.py
@@ -1,0 +1,159 @@
+"""Encrypt existing plaintext secrets in place.
+
+Walks every row that may carry credentials and rewraps the secret values:
+
+- `sources.metadata_`: keys matching SOURCE_SECRET_KEYS get wrapped in
+  `{"__enc": "<fernet>"}` envelopes.
+- `telegram_bot_configs.bot_token`, `whatsapp_bot_configs.(access_token,
+  verify_token)`, `slack_bot_configs.(client_secret, signing_secret,
+  bot_token)`: encrypted in-place.
+
+Idempotent: values that already look like ciphertext (Fernet `gAAAA`
+prefix) or an `{"__enc": "..."}` envelope are skipped.
+
+Revision ID: 20260413130000
+"""
+from __future__ import annotations
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260413130000"
+down_revision: Union[str, None] = "20260413120000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Duplicated from app.services.crypto to keep the migration self-contained.
+# If that set ever expands, this migration stays a snapshot of the old set —
+# a follow-up migration can re-encrypt anything newly classified as secret.
+SOURCE_SECRET_KEYS = frozenset({
+    "password",
+    "connection_string",
+    "service_account_json",
+    "service_account_key",
+    "api_key",
+    "auth_token",
+    "bearer_token",
+    "access_token",
+    "secret_access_key",
+    "aws_secret_access_key",
+    "private_key",
+    "client_secret",
+})
+_FERNET_PREFIX = "gAAAA"
+
+
+def _looks_encrypted(v) -> bool:
+    return isinstance(v, str) and v.startswith(_FERNET_PREFIX)
+
+
+def _wrap_scalar(encrypt, value):
+    if value is None or value == "":
+        return value
+    if isinstance(value, str) and _looks_encrypted(value):
+        return value
+    if isinstance(value, dict) and "__enc" in value:
+        return value
+    return {"__enc": encrypt(value if isinstance(value, str) else str(value))}
+
+
+def _walk_meta(encrypt, node):
+    """Return a deep copy of `node` with SOURCE_SECRET_KEYS values wrapped."""
+    if isinstance(node, dict):
+        out = {}
+        for k, v in node.items():
+            if isinstance(k, str) and k.lower() in SOURCE_SECRET_KEYS:
+                out[k] = _wrap_scalar(encrypt, v)
+            else:
+                out[k] = _walk_meta(encrypt, v)
+        return out
+    if isinstance(node, list):
+        return [_walk_meta(encrypt, v) for v in node]
+    return node
+
+
+def _load_encrypt_callable():
+    """Import `encrypt_text` from the app at runtime. We can't import
+    eagerly at the top of this file because Alembic loads migrations
+    before the app package is necessarily importable in some setups."""
+    from app.services.crypto import encrypt_text
+    return encrypt_text
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    encrypt_text = _load_encrypt_callable()
+
+    inspector = sa.inspect(conn)
+    tables = set(inspector.get_table_names())
+
+    # --- sources.metadata_ ---------------------------------------------------
+    if "sources" in tables:
+        rows = conn.execute(sa.text("SELECT id, metadata FROM sources")).fetchall()
+        for row in rows:
+            source_id = row[0]
+            raw = row[1]
+            if raw is None:
+                continue
+            # SQLite returns JSON columns as strings; Postgres returns dicts.
+            if isinstance(raw, str):
+                try:
+                    meta = json.loads(raw)
+                except (TypeError, ValueError):
+                    continue
+            else:
+                meta = raw
+            if not isinstance(meta, dict):
+                continue
+            rewrapped = _walk_meta(encrypt_text, meta)
+            if rewrapped != meta:
+                conn.execute(
+                    sa.text("UPDATE sources SET metadata = :m WHERE id = :id"),
+                    {"m": json.dumps(rewrapped), "id": source_id},
+                )
+
+    # --- scalar token tables -------------------------------------------------
+    scalar_targets = [
+        ("telegram_bot_configs", ["bot_token"]),
+        ("whatsapp_bot_configs", ["access_token", "verify_token"]),
+        ("slack_bot_configs", ["client_secret", "signing_secret", "bot_token"]),
+    ]
+
+    for table, cols in scalar_targets:
+        if table not in tables:
+            continue
+        col_names = {c["name"] for c in inspector.get_columns(table)}
+        existing_cols = [c for c in cols if c in col_names]
+        if not existing_cols:
+            continue
+        select_sql = f"SELECT id, {', '.join(existing_cols)} FROM {table}"
+        rows = conn.execute(sa.text(select_sql)).fetchall()
+        for row in rows:
+            row_id = row[0]
+            updates: dict[str, str] = {}
+            for i, col in enumerate(existing_cols, start=1):
+                value = row[i]
+                if value is None or value == "":
+                    continue
+                if _looks_encrypted(value):
+                    continue
+                updates[col] = encrypt_text(value)
+            if updates:
+                set_clause = ", ".join(f"{c} = :{c}" for c in updates)
+                params = {**updates, "id": row_id}
+                conn.execute(
+                    sa.text(f"UPDATE {table} SET {set_clause} WHERE id = :id"),
+                    params,
+                )
+
+
+def downgrade() -> None:
+    # Decryption downgrade is not provided: plaintext cannot be recovered
+    # without the Fernet key. Operators who need to roll back should restore
+    # from backup.
+    pass

--- a/backend/alembic/versions/20260414120000_add_org_id_to_remaining_models.py
+++ b/backend/alembic/versions/20260414120000_add_org_id_to_remaining_models.py
@@ -1,0 +1,156 @@
+"""Add organization_id to Dashboard, DashboardChart, QASession, Alert, AlertExecution.
+
+The prior multi-tenant migration tackled the core tenant-scoped models
+(Source, Agent, pipeline_*, api_keys, github_connections). These five
+trailed behind with user_id-only isolation. This migration brings them
+under the tenant scope so the CI lint (next commit) can fail when new
+code queries them without an `organization_id` predicate.
+
+Backfill strategy: inherit `organization_id` from the row's user
+(`users.organization_id`). For AlertExecution and DashboardChart — which
+don't have a direct user_id — inherit from their parent Alert /
+Dashboard.
+
+Revision ID: 20260414120000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260414120000"
+down_revision: Union[str, None] = "20260413130000"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _columns(inspector, table: str) -> set[str]:
+    try:
+        return {c["name"] for c in inspector.get_columns(table)}
+    except Exception:  # noqa: BLE001 — table might not exist
+        return set()
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    tables = set(inspector.get_table_names())
+
+    # --- simple add + backfill from users.organization_id -------------------
+    simple = [
+        "dashboards",
+        "qa_sessions",
+        "alerts",
+    ]
+    for table in simple:
+        if table not in tables:
+            continue
+        cols = _columns(inspector, table)
+        if "organization_id" in cols:
+            continue
+        with op.batch_alter_table(table) as batch:
+            batch.add_column(sa.Column("organization_id", sa.String(36), nullable=True))
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} SET organization_id = ("
+                "  SELECT users.organization_id FROM users "
+                f"  WHERE users.id = {table}.user_id"
+                ") WHERE organization_id IS NULL"
+            )
+        )
+        # Fill any remaining NULLs (orphan rows with no matching user) with
+        # a per-row synthetic UUID so the NOT NULL invariant holds.
+        orphans = conn.execute(
+            sa.text(f"SELECT id FROM {table} WHERE organization_id IS NULL")
+        ).fetchall()
+        for r in orphans:
+            conn.execute(
+                sa.text(f"UPDATE {table} SET organization_id = lower(hex(randomblob(16))) WHERE id = :id"),
+                {"id": r[0]},
+            )
+        with op.batch_alter_table(table) as batch:
+            batch.create_index(f"ix_{table}_organization_id", ["organization_id"])
+
+    # --- dashboard_charts: inherit from parent dashboard --------------------
+    if "dashboard_charts" in tables and "organization_id" not in _columns(
+        inspector, "dashboard_charts"
+    ):
+        with op.batch_alter_table("dashboard_charts") as batch:
+            batch.add_column(sa.Column("organization_id", sa.String(36), nullable=True))
+        conn.execute(
+            sa.text(
+                "UPDATE dashboard_charts SET organization_id = ("
+                "  SELECT dashboards.organization_id FROM dashboards "
+                "  WHERE dashboards.id = dashboard_charts.dashboard_id"
+                ") WHERE organization_id IS NULL"
+            )
+        )
+        orphans = conn.execute(
+            sa.text("SELECT id FROM dashboard_charts WHERE organization_id IS NULL")
+        ).fetchall()
+        for r in orphans:
+            conn.execute(
+                sa.text(
+                    "UPDATE dashboard_charts SET organization_id = lower(hex(randomblob(16))) WHERE id = :id"
+                ),
+                {"id": r[0]},
+            )
+        with op.batch_alter_table("dashboard_charts") as batch:
+            batch.create_index(
+                "ix_dashboard_charts_organization_id", ["organization_id"]
+            )
+
+    # --- alert_executions: inherit from parent alert ------------------------
+    if "alert_executions" in tables and "organization_id" not in _columns(
+        inspector, "alert_executions"
+    ):
+        with op.batch_alter_table("alert_executions") as batch:
+            batch.add_column(sa.Column("organization_id", sa.String(36), nullable=True))
+        conn.execute(
+            sa.text(
+                "UPDATE alert_executions SET organization_id = ("
+                "  SELECT alerts.organization_id FROM alerts "
+                "  WHERE alerts.id = alert_executions.alert_id"
+                ") WHERE organization_id IS NULL"
+            )
+        )
+        orphans = conn.execute(
+            sa.text("SELECT id FROM alert_executions WHERE organization_id IS NULL")
+        ).fetchall()
+        for r in orphans:
+            conn.execute(
+                sa.text(
+                    "UPDATE alert_executions SET organization_id = lower(hex(randomblob(16))) WHERE id = :id"
+                ),
+                {"id": r[0]},
+            )
+        with op.batch_alter_table("alert_executions") as batch:
+            batch.create_index(
+                "ix_alert_executions_organization_id", ["organization_id"]
+            )
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    for table in (
+        "alert_executions",
+        "dashboard_charts",
+        "alerts",
+        "qa_sessions",
+        "dashboards",
+    ):
+        try:
+            cols = _columns(inspector, table)
+        except Exception:  # noqa: BLE001
+            continue
+        if "organization_id" not in cols:
+            continue
+        with op.batch_alter_table(table) as batch:
+            try:
+                batch.drop_index(f"ix_{table}_organization_id")
+            except Exception:  # noqa: BLE001
+                pass
+            batch.drop_column("organization_id")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ from app.routers import shopify_router
 from app.routers import pipeline_runs_router
 from app.routers import pipeline_versions_router
 from app.routers import github_integration_router
+from app.routers import organizations_router
 from app.models import User
 from app.auth import hash_password, GUEST_USER_ID, ADMIN_USER_ID
 
@@ -326,6 +327,7 @@ app.include_router(data_engineering_router.router, prefix=prefix)
 app.include_router(pipeline_runs_router.router, prefix=prefix)
 app.include_router(pipeline_versions_router.router, prefix=prefix)
 app.include_router(github_integration_router.router, prefix=prefix)
+app.include_router(organizations_router.router, prefix=prefix)
 
 
 @app.get(prefix + "/config")

--- a/backend/app/mcp_server.py
+++ b/backend/app/mcp_server.py
@@ -1,6 +1,15 @@
 """
 MCP (Model Context Protocol) server for Data Talks.
 Exposes data analysis tools via SSE transport, mounted on the FastAPI app at /mcp.
+
+Authentication: **every tool call requires an `api_key` parameter** that
+maps to a Data Talks API key (`Settings → API keys` in the UI, or
+`POST /api/api-keys`). There is no guest fallback — an unauthenticated
+HTTP client that reaches /mcp can only receive an authentication error.
+
+The API key carries the organization binding; all tool calls are scoped
+to that organization. A user in multiple orgs must generate one API key
+per org (or switch via JWT-backed HTTP routes and not use MCP).
 """
 from __future__ import annotations
 
@@ -77,7 +86,9 @@ mcp = FastMCP(
     instructions=(
         "Data Talks is an AI-powered data analysis platform. "
         "Use these tools to ask natural language questions about connected data sources, "
-        "list available agents and sources, and browse conversation history."
+        "list available agents and sources, and browse conversation history. "
+        "Every tool call requires an `api_key` parameter — get one at "
+        "Settings → API keys in the Data Talks UI."
     ),
 )
 
@@ -100,73 +111,59 @@ class _McpScope:
 async def _resolve_scope(
     db: AsyncSession, api_key: str | None = None
 ) -> _McpScope:
-    """Resolve an MCP caller's tenant scope.
+    """Resolve an MCP caller's tenant scope from an API key.
 
-    API key is the normal path: the key is tenant-bound, so we look up the
-    caller's membership in the key's organization.
+    An API key is **required** for every MCP call, regardless of the
+    HTTP-side `ENABLE_LOGIN` flag. Before this change the MCP server fell
+    through to the guest user whenever login was disabled, which exposed
+    the full control plane (create_agent, delete_source, create_alert,
+    ask_question, …) to anyone who could reach `/mcp`.
 
-    In guest mode (ENABLE_LOGIN=false) we fall back to the single Guest-org
-    membership so local dev keeps working without an API key.
+    Operators running single-tenant deploys should create one API key via
+    `Settings → API keys` in the UI or `POST /api/api-keys`, and pass it
+    as the `api_key` parameter on every MCP call.
 
-    Raises ValueError if authentication fails. The next commit removes the
-    guest fallback entirely.
+    Raises ValueError on any authentication failure; each MCP tool
+    surfaces that message as its return value so the MCP client sees a
+    helpful error instead of a stack trace.
     """
-    settings = get_settings()
-
-    if api_key:
-        key_hash = _hash_api_key(api_key)
-        r = await db.execute(
-            select(ApiKey).where(ApiKey.key_hash == key_hash, ApiKey.is_active == True)  # noqa: E712
-        )
-        api_key_row = r.scalar_one_or_none()
-        if not api_key_row:
-            raise ValueError("Invalid or inactive API key")
-        r = await db.execute(select(User).where(User.id == api_key_row.user_id))
-        user = r.scalar_one_or_none()
-        if not user:
-            raise ValueError("API key owner not found")
-        api_key_row.last_used_at = datetime.utcnow()
-        await db.flush()
-
-        r = await db.execute(
-            select(OrganizationMembership).where(
-                OrganizationMembership.user_id == user.id,
-                OrganizationMembership.organization_id == api_key_row.organization_id,
-            )
-        )
-        membership = r.scalar_one_or_none()
-        if not membership:
-            raise ValueError(
-                "API key owner has no membership in the key's organization"
-            )
-        return _McpScope(
-            user=user,
-            organization_id=api_key_row.organization_id,
-            role=membership.role,
-            default_agent_id=api_key_row.agent_id,
+    if not api_key:
+        raise ValueError(
+            "Authentication required. MCP always requires an api_key "
+            "parameter — create one at Settings → API keys, or via "
+            "POST /api/api-keys."
         )
 
-    if not settings.enable_login:
-        r = await db.execute(select(User).where(User.id == GUEST_USER_ID))
-        user = r.scalar_one_or_none()
-        if user:
-            r = await db.execute(
-                select(OrganizationMembership)
-                .where(OrganizationMembership.user_id == user.id)
-                .order_by(OrganizationMembership.created_at.asc())
-                .limit(1)
-            )
-            membership = r.scalar_one_or_none()
-            if membership:
-                return _McpScope(
-                    user=user,
-                    organization_id=membership.organization_id,
-                    role=membership.role,
-                    default_agent_id=None,
-                )
+    key_hash = _hash_api_key(api_key)
+    r = await db.execute(
+        select(ApiKey).where(ApiKey.key_hash == key_hash, ApiKey.is_active == True)  # noqa: E712
+    )
+    api_key_row = r.scalar_one_or_none()
+    if not api_key_row:
+        raise ValueError("Invalid or inactive API key")
+    r = await db.execute(select(User).where(User.id == api_key_row.user_id))
+    user = r.scalar_one_or_none()
+    if not user:
+        raise ValueError("API key owner not found")
+    api_key_row.last_used_at = datetime.utcnow()
+    await db.flush()
 
-    raise ValueError(
-        "Authentication required. Provide the api_key parameter with a valid Data Talks API key."
+    r = await db.execute(
+        select(OrganizationMembership).where(
+            OrganizationMembership.user_id == user.id,
+            OrganizationMembership.organization_id == api_key_row.organization_id,
+        )
+    )
+    membership = r.scalar_one_or_none()
+    if not membership:
+        raise ValueError(
+            "API key owner has no membership in the key's organization"
+        )
+    return _McpScope(
+        user=user,
+        organization_id=api_key_row.organization_id,
+        role=membership.role,
+        default_agent_id=api_key_row.agent_id,
     )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from sqlalchemy import String, Text, Boolean, Integer, Float, DateTime, ForeignKey, JSON, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.database import Base
+from app.services.crypto import EncryptedText
 
 
 # ---------------------------------------------------------------------------
@@ -284,12 +285,18 @@ class AudioOverview(Base):
 
 
 class TelegramBotConfig(Base):
-    """User-managed Telegram bot credentials shown in the Connections screen."""
+    """User-managed Telegram bot credentials shown in the Connections screen.
+
+    `bot_token` is transparently Fernet-encrypted at rest via the
+    `EncryptedText` SQLAlchemy type. Existing plaintext rows keep working
+    until the next UPDATE — the data migration that ships this model
+    rewraps any plaintext token on load."""
     __tablename__ = "telegram_bot_configs"
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"))
     name: Mapped[str] = mapped_column(String(128))
-    bot_token: Mapped[str] = mapped_column(String(512))
+    # Encrypted at rest; Python-side attribute is always plaintext.
+    bot_token: Mapped[str] = mapped_column(EncryptedText())
     bot_username: Mapped[str] = mapped_column(String(255))
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -324,14 +331,16 @@ class TelegramConnection(Base):
 
 
 class WhatsAppBotConfig(Base):
-    """User-managed WhatsApp Business API credentials."""
+    """User-managed WhatsApp Business API credentials.
+
+    `access_token` and `verify_token` are Fernet-encrypted at rest."""
     __tablename__ = "whatsapp_bot_configs"
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"))
     name: Mapped[str] = mapped_column(String(128))
     phone_number_id: Mapped[str] = mapped_column(String(64))
-    access_token: Mapped[str] = mapped_column(String(512))
-    verify_token: Mapped[str] = mapped_column(String(128))
+    access_token: Mapped[str] = mapped_column(EncryptedText())
+    verify_token: Mapped[str] = mapped_column(EncryptedText())
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -349,15 +358,18 @@ class WhatsAppConnection(Base):
 
 
 class SlackBotConfig(Base):
-    """User-managed Slack app credentials (obtained via OAuth2 or manual entry)."""
+    """User-managed Slack app credentials (obtained via OAuth2 or manual entry).
+
+    `client_secret`, `signing_secret`, and `bot_token` are Fernet-encrypted
+    at rest."""
     __tablename__ = "slack_bot_configs"
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"))
     name: Mapped[str] = mapped_column(String(128))
     client_id: Mapped[str] = mapped_column(String(128))
-    client_secret: Mapped[str] = mapped_column(String(256))
-    signing_secret: Mapped[str] = mapped_column(String(256))
-    bot_token: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    client_secret: Mapped[str] = mapped_column(EncryptedText())
+    signing_secret: Mapped[str] = mapped_column(EncryptedText())
+    bot_token: Mapped[str | None] = mapped_column(EncryptedText(), nullable=True)
     team_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     team_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -101,6 +101,7 @@ class QASession(Base):
     __tablename__ = "qa_sessions"
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"))
+    organization_id: Mapped[str] = mapped_column(String(36), index=True)
     agent_id: Mapped[str] = mapped_column(String(36))
     source_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     question: Mapped[str] = mapped_column(Text)
@@ -118,6 +119,7 @@ class Dashboard(Base):
     __tablename__ = "dashboards"
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"))
+    organization_id: Mapped[str] = mapped_column(String(36), index=True)
     name: Mapped[str] = mapped_column(String(255))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
@@ -127,6 +129,7 @@ class Dashboard(Base):
 class DashboardChart(Base):
     __tablename__ = "dashboard_charts"
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    organization_id: Mapped[str] = mapped_column(String(36), index=True)
     dashboard_id: Mapped[str] = mapped_column(String(36), ForeignKey("dashboards.id"))
     qa_session_id: Mapped[str] = mapped_column(String(36))
     image_url: Mapped[str | None] = mapped_column(String(1024), nullable=True)
@@ -195,6 +198,7 @@ class Alert(Base):
     __tablename__ = "alerts"
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"))
+    organization_id: Mapped[str] = mapped_column(String(36), index=True)
     agent_id: Mapped[str] = mapped_column(String(36))
     name: Mapped[str] = mapped_column(String(255))
     type: Mapped[str] = mapped_column(String(50), default="alert")  # alert | report
@@ -215,6 +219,7 @@ class AlertExecution(Base):
     """Tracks each execution of an alert."""
     __tablename__ = "alert_executions"
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    organization_id: Mapped[str] = mapped_column(String(36), index=True)
     alert_id: Mapped[str] = mapped_column(String(36), ForeignKey("alerts.id", ondelete="CASCADE"), index=True)
     status: Mapped[str] = mapped_column(String(50))  # success | error
     answer: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/routers/api_keys_router.py
+++ b/backend/app/routers/api_keys_router.py
@@ -8,7 +8,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.auth import require_user, _hash_api_key
+from app.auth import TenantScope, require_membership, require_user, _hash_api_key
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Agent, ApiKey
 from app.schemas import ApiKeyCreate, ApiKeyOut, ApiKeyCreated
 
@@ -39,9 +40,9 @@ def _row_to_out(k: ApiKey) -> ApiKeyOut:
 async def list_api_keys(
     agent_id: str | None = None,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
-    q = select(ApiKey).where(ApiKey.user_id == user.id).order_by(ApiKey.created_at.desc())
+    q = select(ApiKey).where(tenant_filter(ApiKey, scope)).order_by(ApiKey.created_at.desc())
     if agent_id:
         q = q.where(ApiKey.agent_id == agent_id)
     result = await db.execute(q)
@@ -53,10 +54,10 @@ async def list_api_keys(
 async def create_api_key(
     body: ApiKeyCreate,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     # Verify agent exists and belongs to user
-    r = await db.execute(select(Agent).where(Agent.id == body.agent_id, Agent.user_id == user.id))
+    r = await db.execute(select(Agent).where(Agent.id == body.agent_id, tenant_filter(Agent, scope)))
     if not r.scalar_one_or_none():
         raise HTTPException(404, "Agent not found")
 
@@ -92,9 +93,9 @@ async def create_api_key(
 async def delete_api_key(
     key_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(ApiKey).where(ApiKey.id == key_id, ApiKey.user_id == user.id))
+    r = await db.execute(select(ApiKey).where(ApiKey.id == key_id, tenant_filter(ApiKey, scope)))
     key = r.scalar_one_or_none()
     if not key:
         raise HTTPException(404, "API key not found")
@@ -108,9 +109,9 @@ async def update_api_key(
     key_id: str,
     body: dict,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(ApiKey).where(ApiKey.id == key_id, ApiKey.user_id == user.id))
+    r = await db.execute(select(ApiKey).where(ApiKey.id == key_id, tenant_filter(ApiKey, scope)))
     key = r.scalar_one_or_none()
     if not key:
         raise HTTPException(404, "API key not found")

--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -14,7 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.database import get_db
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.llm.charting import build_chart_plan
 from app.models import Agent, Source, QASession, LlmSettings, LlmConfig
 from app.models import User
@@ -805,7 +806,12 @@ async def dispatch_question(
     }
 
     if session_id:
-        r = await db.execute(select(QASession).where(QASession.id == session_id))
+        r = await db.execute(
+            select(QASession).where(
+                QASession.id == session_id,
+                QASession.organization_id == agent.organization_id,
+            )
+        )
         qa = r.scalar_one_or_none()
         if qa:
             updated_history = [*(qa.conversation_history or []), conversation_entry]
@@ -868,24 +874,24 @@ async def dispatch_question(
 async def ask_question(
     body: AskQuestionRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     channel = body.channel or "workspace"
     if not body.agentId:
         raise HTTPException(400, "agentId is required")
 
     # Load agent
-    r = await db.execute(select(Agent).where(Agent.id == body.agentId))
+    r = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Agent not found")
 
     # Agent sources: by source_ids on agent or by agent_id on source
     if agent.source_ids:
-        r = await db.execute(select(Source).where(Source.id.in_(agent.source_ids)))
+        r = await db.execute(select(Source).where(Source.id.in_(agent.source_ids), tenant_filter(Source, scope)))
         sources = list(r.scalars().all())
     else:
-        r = await db.execute(select(Source).where(Source.agent_id == body.agentId))
+        r = await db.execute(select(Source).where(Source.agent_id == body.agentId, tenant_filter(Source, scope)))
         sources = list(r.scalars().all())
 
     if not sources:
@@ -922,7 +928,12 @@ async def ask_question(
     history = []
     session_id = body.sessionId
     if session_id:
-        r_qa = await db.execute(select(QASession).where(QASession.id == session_id))
+        r_qa = await db.execute(
+            select(QASession).where(
+                QASession.id == session_id,
+                QASession.organization_id == agent.organization_id,
+            )
+        )
         qa_session = r_qa.scalar_one_or_none()
         if qa_session and qa_session.conversation_history:
             history = qa_session.conversation_history
@@ -957,9 +968,9 @@ async def generate_chart_for_turn(
     session_id: str,
     body: GenerateChartRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(QASession).where(QASession.id == session_id, QASession.user_id == user.id))
+    r = await db.execute(select(QASession).where(QASession.id == session_id, tenant_filter(QASession, scope), QASession.user_id == user.id))
     qa = r.scalar_one_or_none()
     if not qa:
         raise HTTPException(404, "Session not found")
@@ -975,7 +986,7 @@ async def generate_chart_for_turn(
             "turnId": turn_id,
         }
 
-    agent_row = await db.execute(select(Agent).where(Agent.id == qa.agent_id))
+    agent_row = await db.execute(select(Agent).where(Agent.id == qa.agent_id, tenant_filter(Agent, scope)))
     agent = agent_row.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Agent not found")
@@ -1024,9 +1035,9 @@ async def get_chart_image(
     session_id: str,
     turn_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(QASession).where(QASession.id == session_id, QASession.user_id == user.id))
+    r = await db.execute(select(QASession).where(QASession.id == session_id, tenant_filter(QASession, scope), QASession.user_id == user.id))
     qa = r.scalar_one_or_none()
     if not qa:
         raise HTTPException(404, "Session not found")

--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -203,6 +203,13 @@ async def dispatch_question(
     if history is None:
         history = []
 
+    # Transparently decrypt per-source credentials (password, api_key,
+    # service_account_json, etc.) before dispatching. Downstream scripts and
+    # the multi-SQL assembly read `source.metadata_` directly.
+    from app.services.crypto import unlock_source_metadata
+    for _s in sources:
+        unlock_source_metadata(_s)
+
     multi_sql_sources, multi_sql_relationships = _build_active_multi_sql_sources(agent, sources)
     active_sources = [s for s in sources if s.is_active]
     source = active_sources[0] if active_sources else sources[0]

--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -826,6 +826,7 @@ async def dispatch_question(
         qa = QASession(
             id=str(uuid.uuid4()),
             user_id=user.id,
+            organization_id=agent.organization_id,
             agent_id=agent.id,
             source_id=source.id,
             question=question,

--- a/backend/app/routers/audio_overview_router.py
+++ b/backend/app/routers/audio_overview_router.py
@@ -12,7 +12,8 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.config import get_settings
 from app.database import get_db
 from app.llm.client import chat_completion, get_audio_model, synthesize_speech
@@ -80,17 +81,22 @@ async def _effective_llm_overrides(db: AsyncSession, user: User, agent: Agent) -
     return _llm_config_to_overrides(llm_row)
 
 
-async def _resolve_source(db: AsyncSession, user: User, agent_id: str, source_id: str | None) -> Source:
+async def _resolve_source(
+    db: AsyncSession,
+    scope: TenantScope,
+    agent_id: str,
+    source_id: str | None,
+) -> Source:
     if source_id:
-        r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+        r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
         source = r.scalar_one_or_none()
     else:
         r = await db.execute(
-            select(Source).where(Source.agent_id == agent_id, Source.user_id == user.id, Source.is_active == True)
+            select(Source).where(Source.agent_id == agent_id, tenant_filter(Source, scope), Source.is_active == True)
         )
         source = r.scalar_one_or_none()
         if not source:
-            r = await db.execute(select(Source).where(Source.agent_id == agent_id, Source.user_id == user.id))
+            r = await db.execute(select(Source).where(Source.agent_id == agent_id, tenant_filter(Source, scope)))
             source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(400, "No source found for this workspace")
@@ -194,17 +200,17 @@ async def _build_audio_script(source_name: str, report: str, llm_overrides: dict
 async def generate_audio_overview(
     body: GenerateAudioOverviewRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     if not body.agentId:
         raise HTTPException(400, "agentId is required")
 
-    r = await db.execute(select(Agent).where(Agent.id == body.agentId))
+    r = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Agent not found")
 
-    llm_overrides = await _effective_llm_overrides(db, user, agent)
+    llm_overrides = await _effective_llm_overrides(db, scope.user, agent)
     provider, audio_model = get_audio_model(llm_overrides)
     if provider not in ("openai", "litellm") or not audio_model:
         raise HTTPException(
@@ -212,7 +218,7 @@ async def generate_audio_overview(
             "Configure an audio model in Account > LLM / AI settings for the current workspace model before generating audio.",
         )
 
-    source = await _resolve_source(db, user, body.agentId, body.sourceId)
+    source = await _resolve_source(db, scope, body.agentId, body.sourceId)
     report = await _generate_source_summary_report(source, llm_overrides)
     script = await _build_audio_script(source.name, report, llm_overrides)
     audio_bytes, mime_type, _ = await synthesize_speech(script, llm_overrides=llm_overrides)
@@ -220,12 +226,12 @@ async def generate_audio_overview(
     from app.services.storage import get_storage
     audio_id = str(uuid.uuid4())
     ext = ".mp3" if mime_type == "audio/mpeg" else ".bin"
-    relative_path = f"audio_overviews/{user.id}/{audio_id}{ext}"
+    relative_path = f"audio_overviews/{scope.user.id}/{audio_id}{ext}"
     get_storage().write_bytes(relative_path, audio_bytes)
 
     overview = AudioOverview(
         id=audio_id,
-        user_id=user.id,
+        user_id=scope.user.id,
         agent_id=body.agentId,
         source_id=source.id,
         source_name=source.name,
@@ -251,9 +257,9 @@ async def generate_audio_overview(
 async def list_audio_overviews(
     agent_id: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
-    q = select(AudioOverview).where(AudioOverview.user_id == user.id).order_by(AudioOverview.created_at.desc())
+    q = select(AudioOverview).where(AudioOverview.user_id == scope.user.id).order_by(AudioOverview.created_at.desc())
     if agent_id:
         q = q.where(AudioOverview.agent_id == agent_id)
     r = await db.execute(q)
@@ -276,9 +282,9 @@ async def list_audio_overviews(
 async def get_audio_file(
     audio_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(AudioOverview).where(AudioOverview.id == audio_id, AudioOverview.user_id == user.id))
+    r = await db.execute(select(AudioOverview).where(AudioOverview.id == audio_id, AudioOverview.user_id == scope.user.id))
     row = r.scalar_one_or_none()
     if not row:
         raise HTTPException(404, "Audio overview not found")
@@ -295,9 +301,9 @@ async def get_audio_file(
 async def delete_audio_overview(
     audio_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(AudioOverview).where(AudioOverview.id == audio_id, AudioOverview.user_id == user.id))
+    r = await db.execute(select(AudioOverview).where(AudioOverview.id == audio_id, AudioOverview.user_id == scope.user.id))
     row = r.scalar_one_or_none()
     if not row:
         raise HTTPException(404, "Audio overview not found")

--- a/backend/app/routers/automl_router.py
+++ b/backend/app/routers/automl_router.py
@@ -11,7 +11,8 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.config import get_settings
 from app.database import get_db
 from app.models import Agent, AutoMLRun, LlmConfig, LlmSettings, Source, User
@@ -148,16 +149,16 @@ class ColumnsRequest(BaseModel):
 async def train_automl(
     body: TrainRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Train an Auto ML model on the selected source and target column."""
-    r = await db.execute(select(Agent).where(Agent.id == body.agentId))
+    r = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Agent not found")
 
     r = await db.execute(
-        select(Source).where(Source.id == body.sourceId, Source.user_id == user.id)
+        select(Source).where(Source.id == body.sourceId, tenant_filter(Source, scope))
     )
     source = r.scalar_one_or_none()
     if not source:
@@ -198,11 +199,11 @@ async def get_columns(
     agent_id: str,
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Return column names for the given source."""
     r = await db.execute(
-        select(Source).where(Source.id == source_id, Source.user_id == user.id)
+        select(Source).where(Source.id == source_id, tenant_filter(Source, scope))
     )
     source = r.scalar_one_or_none()
     if not source:
@@ -215,7 +216,7 @@ async def get_columns(
 async def list_runs(
     agent_id: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List Auto ML runs, optionally filtered by workspace."""
     q = (
@@ -233,7 +234,7 @@ async def list_runs(
 async def get_run(
     run_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Get a single Auto ML run."""
     r = await db.execute(
@@ -249,7 +250,7 @@ async def get_run(
 async def delete_run(
     run_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Delete an Auto ML run."""
     r = await db.execute(

--- a/backend/app/routers/bigquery_router.py
+++ b/backend/app/routers/bigquery_router.py
@@ -8,7 +8,8 @@ BigQuery discovery and source metadata refresh.
 import asyncio
 import json
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User
 from app.database import get_db, AsyncSessionLocal
 from sqlalchemy import select
@@ -23,14 +24,14 @@ router = APIRouter(prefix="/bigquery", tags=["bigquery"])
 @router.post("/projects")
 async def list_projects(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List projects. Body: { "credentialsContent": "..." } or { "sourceId": "..." }."""
     credentials_content = body.get("credentialsContent") or body.get("credentials_content")
     source_id = body.get("sourceId")
     if source_id:
         async with AsyncSessionLocal() as db:
-            r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+            r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
             source = r.scalar_one_or_none()
             if not source or source.type != "bigquery":
                 raise HTTPException(404, "BigQuery source not found")
@@ -53,7 +54,7 @@ async def list_projects(
 @router.post("/datasets")
 async def list_datasets(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List datasets in a project. Body: { credentialsContent or sourceId, projectId }."""
     credentials_content = body.get("credentialsContent") or body.get("credentials_content")
@@ -64,7 +65,7 @@ async def list_datasets(
     if source_id and not credentials_content:
         from app.database import async_session_maker
         async with async_session_maker() as db:
-            r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+            r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
             source = r.scalar_one_or_none()
             if not source or source.type != "bigquery":
                 raise HTTPException(404, "BigQuery source not found")
@@ -89,7 +90,7 @@ async def list_datasets(
 @router.post("/tables")
 async def list_tables(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List tables in a dataset. Body: { credentialsContent or sourceId, projectId, datasetId }."""
     credentials_content = body.get("credentialsContent") or body.get("credentials_content")
@@ -100,7 +101,7 @@ async def list_tables(
         raise HTTPException(400, "projectId and datasetId are required")
     if source_id and not credentials_content:
         async with AsyncSessionLocal() as db:
-            r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+            r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
             source = r.scalar_one_or_none()
             if not source or source.type != "bigquery":
                 raise HTTPException(404, "BigQuery source not found")
@@ -125,10 +126,10 @@ async def list_tables(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Fetch BigQuery schema (table_infos) for the source and update metadata. Returns updated metaJSON."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")
@@ -185,10 +186,10 @@ async def fetch_full_table(
     source_id: str,
     body: dict | None = None,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Fetch full BigQuery table data (up to limit rows). For graphs and full preview. Body: { limit?: number } default 50000."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/cdp_router.py
+++ b/backend/app/routers/cdp_router.py
@@ -12,7 +12,8 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.config import get_settings
 from app.database import get_db
 from app.models import User, Agent, Source, LlmConfig
@@ -45,7 +46,7 @@ class CdpSegmentRequest(BaseModel):
 
 
 async def _get_agent_and_llm(agent_id: str, user: User, db: AsyncSession):
-    r = await db.execute(select(Agent).where(Agent.id == agent_id, Agent.user_id == user.id))
+    r = await db.execute(select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Workspace not found")
@@ -64,7 +65,7 @@ async def _get_agent_and_llm(agent_id: str, user: User, db: AsyncSession):
 @router.post("/identity-resolution")
 async def suggest_identity_resolution(
     body: CdpRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """AI suggests how to unify customer records across sources."""
@@ -72,7 +73,7 @@ async def suggest_identity_resolution(
 
     # Load all active sources for this workspace
     r = await db.execute(
-        select(Source).where(Source.agent_id == agent.id, Source.user_id == user.id)
+        select(Source).where(Source.agent_id == agent.id, tenant_filter(Source, scope))
     )
     sources = list(r.scalars().all())
     if len(sources) < 1:
@@ -97,7 +98,7 @@ async def suggest_identity_resolution(
 @router.post("/enrichment")
 async def suggest_enrichment(
     body: CdpEnrichRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """AI suggests customer metrics to calculate."""
@@ -125,7 +126,7 @@ async def suggest_enrichment(
 @router.post("/segmentation")
 async def suggest_segmentation(
     body: CdpSegmentRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """AI suggests customer segmentation rules."""
@@ -153,11 +154,11 @@ async def suggest_segmentation(
 @router.get("/config/{agent_id}")
 async def get_cdp_config(
     agent_id: str,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """Get the CDP configuration for a workspace."""
-    r = await db.execute(select(Agent).where(Agent.id == agent_id, Agent.user_id == user.id))
+    r = await db.execute(select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Workspace not found")
@@ -182,14 +183,14 @@ def _make_table_name_from_source(name: str) -> str:
 @router.post("/materialize")
 async def materialize_cdp_table(
     body: MaterializeRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """Execute CDP SQL against all workspace sources and save result as a new CSV source."""
     from app.scripts.ask_csv import _load_full_dataframe
     from app.routers.crud import _build_sample_profile, _sanitize_for_json
 
-    r = await db.execute(select(Agent).where(Agent.id == body.agentId, Agent.user_id == user.id))
+    r = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Workspace not found")
@@ -202,7 +203,7 @@ async def materialize_cdp_table(
     source_ids = agent.source_ids or []
     r_src = await db.execute(
         select(Source).where(
-            Source.user_id == user.id,
+            tenant_filter(Source, scope),
             or_(
                 Source.agent_id == agent.id,
                 Source.id.in_(source_ids) if source_ids else Source.agent_id == agent.id,

--- a/backend/app/routers/crud.py
+++ b/backend/app/routers/crud.py
@@ -504,7 +504,7 @@ async def delete_agent(agent_id: str, db: AsyncSession = Depends(get_db), scope:
 # --- QA Sessions ---
 @router.get("/qa_sessions")
 async def list_qa_sessions(agent_id: Optional[str] = None, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    q = select(QASession).where(QASession.user_id == scope.user.id, QASession.deleted_at.is_(None)).order_by(QASession.created_at.desc())
+    q = select(QASession).where(tenant_filter(QASession, scope), QASession.deleted_at.is_(None)).order_by(QASession.created_at.desc())
     if agent_id:
         q = q.where(QASession.agent_id == agent_id)
     r = await db.execute(q)
@@ -530,7 +530,7 @@ async def list_qa_sessions(agent_id: Optional[str] = None, db: AsyncSession = De
 
 @router.delete("/qa_sessions/{session_id}")
 async def soft_delete_qa_session(session_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(QASession).where(QASession.id == session_id, QASession.user_id == scope.user.id))
+    r = await db.execute(select(QASession).where(QASession.id == session_id, tenant_filter(QASession, scope)))
     s = r.scalar_one_or_none()
     if not s:
         raise HTTPException(404, "Session not found")
@@ -541,7 +541,7 @@ async def soft_delete_qa_session(session_id: str, db: AsyncSession = Depends(get
 
 @router.patch("/qa_sessions/{session_id}")
 async def update_qa_session(session_id: str, body: dict, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(QASession).where(QASession.id == session_id, QASession.user_id == scope.user.id))
+    r = await db.execute(select(QASession).where(QASession.id == session_id, tenant_filter(QASession, scope)))
     s = r.scalar_one_or_none()
     if not s:
         raise HTTPException(404, "Session not found")
@@ -553,7 +553,7 @@ async def update_qa_session(session_id: str, body: dict, db: AsyncSession = Depe
 
 @router.patch("/qa_sessions/{session_id}/feedback")
 async def update_qa_feedback(session_id: str, body: dict, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(QASession).where(QASession.id == session_id, QASession.user_id == scope.user.id))
+    r = await db.execute(select(QASession).where(QASession.id == session_id, tenant_filter(QASession, scope)))
     s = r.scalar_one_or_none()
     if not s:
         raise HTTPException(404, "Session not found")
@@ -566,7 +566,7 @@ async def update_qa_feedback(session_id: str, body: dict, db: AsyncSession = Dep
 @router.get("/dashboards")
 async def list_dashboards(db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
     from sqlalchemy import func
-    r = await db.execute(select(Dashboard).where(Dashboard.user_id == scope.user.id).order_by(Dashboard.updated_at.desc()))
+    r = await db.execute(select(Dashboard).where(tenant_filter(Dashboard, scope)).order_by(Dashboard.updated_at.desc()))
     dashboards = list(r.scalars().all())
     out = []
     for d in dashboards:
@@ -579,7 +579,13 @@ async def list_dashboards(db: AsyncSession = Depends(get_db), scope: TenantScope
 @router.post("/dashboards")
 async def create_dashboard(body: dict, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
     dash_id = str(uuid.uuid4())
-    d = Dashboard(id=dash_id, user_id=scope.user.id, name=body.get("name", ""), description=body.get("description"))
+    d = Dashboard(
+        id=dash_id,
+        user_id=scope.user.id,
+        organization_id=scope.organization_id,
+        name=body.get("name", ""),
+        description=body.get("description"),
+    )
     db.add(d)
     await db.commit()
     return {"id": d.id, "name": d.name, "description": d.description, "created_at": d.created_at.isoformat(), "updated_at": d.updated_at.isoformat()}
@@ -587,7 +593,7 @@ async def create_dashboard(body: dict, db: AsyncSession = Depends(get_db), scope
 
 @router.get("/dashboards/{dashboard_id}")
 async def get_dashboard(dashboard_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(Dashboard).where(Dashboard.id == dashboard_id, Dashboard.user_id == scope.user.id))
+    r = await db.execute(select(Dashboard).where(Dashboard.id == dashboard_id, tenant_filter(Dashboard, scope)))
     d = r.scalar_one_or_none()
     if not d:
         raise HTTPException(404, "Dashboard not found")
@@ -603,7 +609,7 @@ async def get_dashboard(dashboard_id: str, db: AsyncSession = Depends(get_db), s
 
 @router.patch("/dashboards/{dashboard_id}")
 async def update_dashboard(dashboard_id: str, body: dict, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(Dashboard).where(Dashboard.id == dashboard_id, Dashboard.user_id == scope.user.id))
+    r = await db.execute(select(Dashboard).where(Dashboard.id == dashboard_id, tenant_filter(Dashboard, scope)))
     d = r.scalar_one_or_none()
     if not d:
         raise HTTPException(404, "Dashboard not found")
@@ -617,7 +623,7 @@ async def update_dashboard(dashboard_id: str, body: dict, db: AsyncSession = Dep
 
 @router.delete("/dashboards/{dashboard_id}")
 async def delete_dashboard(dashboard_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(Dashboard).where(Dashboard.id == dashboard_id, Dashboard.user_id == scope.user.id))
+    r = await db.execute(select(Dashboard).where(Dashboard.id == dashboard_id, tenant_filter(Dashboard, scope)))
     d = r.scalar_one_or_none()
     if not d:
         raise HTTPException(404, "Dashboard not found")
@@ -631,7 +637,7 @@ async def delete_dashboard(dashboard_id: str, db: AsyncSession = Depends(get_db)
 
 @router.post("/dashboards/{dashboard_id}/charts")
 async def add_chart_to_dashboard(dashboard_id: str, body: dict, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(Dashboard).where(Dashboard.id == dashboard_id, Dashboard.user_id == scope.user.id))
+    r = await db.execute(select(Dashboard).where(Dashboard.id == dashboard_id, tenant_filter(Dashboard, scope)))
     d = r.scalar_one_or_none()
     if not d:
         raise HTTPException(404, "Dashboard not found")
@@ -644,7 +650,15 @@ async def add_chart_to_dashboard(dashboard_id: str, body: dict, db: AsyncSession
     if not image_url:
         raise HTTPException(400, "Session has no image to add to dashboard")
     chart_id = str(uuid.uuid4())
-    c = DashboardChart(id=chart_id, dashboard_id=dashboard_id, qa_session_id=qa_session_id or "", image_url=image_url, title=body.get("title"), description=body.get("description"))
+    c = DashboardChart(
+        id=chart_id,
+        organization_id=scope.organization_id,
+        dashboard_id=dashboard_id,
+        qa_session_id=qa_session_id or "",
+        image_url=image_url,
+        title=body.get("title"),
+        description=body.get("description"),
+    )
     db.add(c)
     await db.commit()
     return {"id": c.id, "dashboard_id": c.dashboard_id, "qa_session_id": c.qa_session_id, "image_url": c.image_url, "title": c.title, "description": c.description}
@@ -656,7 +670,7 @@ async def remove_chart_from_dashboard(chart_id: str, db: AsyncSession = Depends(
     c = r.scalar_one_or_none()
     if not c:
         raise HTTPException(404, "Chart not found")
-    rd = await db.execute(select(Dashboard).where(Dashboard.id == c.dashboard_id, Dashboard.user_id == scope.user.id))
+    rd = await db.execute(select(Dashboard).where(Dashboard.id == c.dashboard_id, tenant_filter(Dashboard, scope)))
     if not rd.scalar_one_or_none():
         raise HTTPException(403, "Not authorized")
     await db.delete(c)
@@ -670,7 +684,7 @@ async def update_dashboard_chart(chart_id: str, body: dict, db: AsyncSession = D
     c = r.scalar_one_or_none()
     if not c:
         raise HTTPException(404, "Chart not found")
-    rd = await db.execute(select(Dashboard).where(Dashboard.id == c.dashboard_id, Dashboard.user_id == scope.user.id))
+    rd = await db.execute(select(Dashboard).where(Dashboard.id == c.dashboard_id, tenant_filter(Dashboard, scope)))
     if not rd.scalar_one_or_none():
         raise HTTPException(403, "Not authorized")
     if "title" in body:
@@ -931,7 +945,7 @@ def _serialize_alert(a: Alert) -> dict:
 
 @router.get("/alerts")
 async def list_alerts(agent_id: Optional[str] = None, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    q = select(Alert).where(Alert.user_id == scope.user.id)
+    q = select(Alert).where(tenant_filter(Alert, scope))
     if agent_id:
         q = q.where(Alert.agent_id == agent_id)
     q = q.order_by(Alert.created_at.desc())
@@ -947,6 +961,7 @@ async def create_alert(body: dict, db: AsyncSession = Depends(get_db), scope: Te
     a = Alert(
         id=alert_id,
         user_id=scope.user.id,
+        organization_id=scope.organization_id,
         agent_id=body["agentId"],
         name=body.get("name", ""),
         type=body.get("type", "alert"),
@@ -968,7 +983,7 @@ async def create_alert(body: dict, db: AsyncSession = Depends(get_db), scope: Te
 async def update_alert(alert_id: str, body: dict, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
     from app.services.alert_scheduler import _compute_next_run
 
-    r = await db.execute(select(Alert).where(Alert.id == alert_id, Alert.user_id == scope.user.id))
+    r = await db.execute(select(Alert).where(Alert.id == alert_id, tenant_filter(Alert, scope)))
     a = r.scalar_one_or_none()
     if not a:
         raise HTTPException(404, "Alert not found")
@@ -1003,7 +1018,7 @@ async def update_alert(alert_id: str, body: dict, db: AsyncSession = Depends(get
 
 @router.delete("/alerts/{alert_id}")
 async def delete_alert(alert_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(Alert).where(Alert.id == alert_id, Alert.user_id == scope.user.id))
+    r = await db.execute(select(Alert).where(Alert.id == alert_id, tenant_filter(Alert, scope)))
     a = r.scalar_one_or_none()
     if not a:
         raise HTTPException(404, "Alert not found")
@@ -1018,7 +1033,7 @@ async def delete_alert(alert_id: str, db: AsyncSession = Depends(get_db), scope:
 @router.post("/alerts/{alert_id}/test")
 async def test_alert(alert_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
     """Execute an alert immediately for testing purposes."""
-    r = await db.execute(select(Alert).where(Alert.id == alert_id, Alert.user_id == scope.user.id))
+    r = await db.execute(select(Alert).where(Alert.id == alert_id, tenant_filter(Alert, scope)))
     a = r.scalar_one_or_none()
     if not a:
         raise HTTPException(404, "Alert not found")
@@ -1032,7 +1047,7 @@ async def test_alert(alert_id: str, db: AsyncSession = Depends(get_db), scope: T
 async def list_alert_executions(alert_id: str, limit: int = 20, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
     """List recent executions for an alert."""
     # Verify ownership
-    r = await db.execute(select(Alert).where(Alert.id == alert_id, Alert.user_id == scope.user.id))
+    r = await db.execute(select(Alert).where(Alert.id == alert_id, tenant_filter(Alert, scope)))
     if not r.scalar_one_or_none():
         raise HTTPException(404, "Alert not found")
 

--- a/backend/app/routers/crud.py
+++ b/backend/app/routers/crud.py
@@ -597,7 +597,7 @@ async def get_dashboard(dashboard_id: str, db: AsyncSession = Depends(get_db), s
     d = r.scalar_one_or_none()
     if not d:
         raise HTTPException(404, "Dashboard not found")
-    r2 = await db.execute(select(DashboardChart).where(DashboardChart.dashboard_id == d.id))
+    r2 = await db.execute(select(DashboardChart).where(DashboardChart.dashboard_id == d.id, tenant_filter(DashboardChart, scope)))
     charts = list(r2.scalars().all())
     return {
         "id": d.id,
@@ -627,7 +627,7 @@ async def delete_dashboard(dashboard_id: str, db: AsyncSession = Depends(get_db)
     d = r.scalar_one_or_none()
     if not d:
         raise HTTPException(404, "Dashboard not found")
-    r2 = await db.execute(select(DashboardChart).where(DashboardChart.dashboard_id == dashboard_id))
+    r2 = await db.execute(select(DashboardChart).where(DashboardChart.dashboard_id == dashboard_id, tenant_filter(DashboardChart, scope)))
     for c in r2.scalars().all():
         await db.delete(c)
     await db.delete(d)
@@ -644,7 +644,7 @@ async def add_chart_to_dashboard(dashboard_id: str, body: dict, db: AsyncSession
     qa_session_id = body.get("qaSessionId")
     image_url = body.get("imageUrl")
     if not image_url:
-        rq = await db.execute(select(QASession).where(QASession.id == qa_session_id))
+        rq = await db.execute(select(QASession).where(QASession.id == qa_session_id, tenant_filter(QASession, scope)))
         qa = rq.scalar_one_or_none()
         image_url = (qa.table_data or {}).get("image_url") if qa else None
     if not image_url:
@@ -666,7 +666,7 @@ async def add_chart_to_dashboard(dashboard_id: str, body: dict, db: AsyncSession
 
 @router.delete("/dashboard_charts/{chart_id}")
 async def remove_chart_from_dashboard(chart_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(DashboardChart).where(DashboardChart.id == chart_id))
+    r = await db.execute(select(DashboardChart).where(DashboardChart.id == chart_id, tenant_filter(DashboardChart, scope)))
     c = r.scalar_one_or_none()
     if not c:
         raise HTTPException(404, "Chart not found")
@@ -680,7 +680,7 @@ async def remove_chart_from_dashboard(chart_id: str, db: AsyncSession = Depends(
 
 @router.patch("/dashboard_charts/{chart_id}")
 async def update_dashboard_chart(chart_id: str, body: dict, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership)):
-    r = await db.execute(select(DashboardChart).where(DashboardChart.id == chart_id))
+    r = await db.execute(select(DashboardChart).where(DashboardChart.id == chart_id, tenant_filter(DashboardChart, scope)))
     c = r.scalar_one_or_none()
     if not c:
         raise HTTPException(404, "Chart not found")
@@ -902,12 +902,12 @@ async def create_demo_workspace(body: dict, db: AsyncSession = Depends(get_db), 
     # Link sources to agent
     for src_id in source_ids:
         await db.execute(
-            select(Source).where(Source.id == src_id)
+            select(Source).where(Source.id == src_id, tenant_filter(Source, scope))
         )
 
     await db.flush()
     for src_id in source_ids:
-        r_src = await db.execute(select(Source).where(Source.id == src_id))
+        r_src = await db.execute(select(Source).where(Source.id == src_id, tenant_filter(Source, scope)))
         s = r_src.scalar_one_or_none()
         if s:
             s.agent_id = agent.id
@@ -1053,7 +1053,10 @@ async def list_alert_executions(alert_id: str, limit: int = 20, db: AsyncSession
 
     r = await db.execute(
         select(AlertExecution)
-        .where(AlertExecution.alert_id == alert_id)
+        .where(
+            AlertExecution.alert_id == alert_id,
+            tenant_filter(AlertExecution, scope),
+        )
         .order_by(AlertExecution.created_at.desc())
         .limit(limit)
     )

--- a/backend/app/routers/crud.py
+++ b/backend/app/routers/crud.py
@@ -17,6 +17,7 @@ from app.database import get_db
 from app.models import User, Source, Agent, QASession, Dashboard, DashboardChart, Alert, AlertExecution, LlmConfig
 from app.auth import TenantScope, require_membership, require_role, require_user
 from app.config import get_settings
+from app.services.crypto import encrypt_secret_fields, mask_secret_fields
 from app.services.tenant_scope import tenant_filter
 
 router = APIRouter(tags=["crud"])
@@ -126,7 +127,9 @@ async def list_sources(
             "agent_id": s.agent_id,
             "is_active": s.is_active,
             "createdAt": s.created_at.isoformat() if s.created_at else None,
-            "metaJSON": _sanitize_for_json(s.metadata_) if s.metadata_ else {},
+            # Mask secret fields in list responses so credentials never
+            # leave the server in the clear after the initial POST /sources.
+            "metaJSON": _sanitize_for_json(mask_secret_fields(s.metadata_)) if s.metadata_ else {},
             "langflowPath": s.langflow_path,
             "langflowName": s.langflow_name,
         }
@@ -152,6 +155,11 @@ async def create_source(
     if body.type not in valid_types:
         raise HTTPException(400, f"type must be one of: {', '.join(valid_types)}")
     source_id = str(uuid.uuid4())
+    # Wrap secret fields (api_key, password, connection_string, ...) in
+    # Fernet envelopes before persisting. The metadata is returned to the
+    # client with secrets masked so the plaintext never leaves the server
+    # after the initial POST echo.
+    encrypted_meta = encrypt_secret_fields(body.metadata)
     source = Source(
         id=source_id,
         user_id=scope.user.id,
@@ -159,17 +167,18 @@ async def create_source(
         agent_id=body.agent_id,
         name=body.name,
         type=body.type,
-        metadata_=body.metadata,
+        metadata_=encrypted_meta,
     )
     db.add(source)
     await db.commit()
+    masked_meta = mask_secret_fields(encrypted_meta) or {}
     return {
         "id": source.id,
         "name": source.name,
         "type": source.type,
         "ownerId": source.user_id,
         "createdAt": source.created_at.isoformat(),
-        "metaJSON": _sanitize_for_json(source.metadata_) if source.metadata_ else {},
+        "metaJSON": _sanitize_for_json(masked_meta),
         "langflowPath": None,
         "langflowName": None,
     }

--- a/backend/app/routers/data_engineering_router.py
+++ b/backend/app/routers/data_engineering_router.py
@@ -14,7 +14,8 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.database import get_db
 from app.models import User, Agent, Source, LlmConfig
 from app.llm.client import chat_completion
@@ -33,13 +34,13 @@ class ToolRequest(BaseModel):
 
 
 async def _get_agent_sources_llm(agent_id: str, user: User, db: AsyncSession):
-    r = await db.execute(select(Agent).where(Agent.id == agent_id, Agent.user_id == user.id))
+    r = await db.execute(select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Workspace not found")
 
     r_src = await db.execute(
-        select(Source).where(Source.user_id == user.id, Source.agent_id == agent.id)
+        select(Source).where(tenant_filter(Source, scope), Source.agent_id == agent.id)
     )
     sources = list(r_src.scalars().all())
 
@@ -89,7 +90,7 @@ async def _call_llm(system: str, user_msg: str, llm_overrides: dict | None, max_
 # ---------------------------------------------------------------------------
 
 @router.post("/schema-docs")
-async def generate_schema_docs(body: ToolRequest, user: User = Depends(require_user), db: AsyncSession = Depends(get_db)):
+async def generate_schema_docs(body: ToolRequest, scope: TenantScope = Depends(require_membership), db: AsyncSession = Depends(get_db)):
     """Generate a data dictionary with LLM-inferred descriptions for all columns."""
     agent, sources, llm = await _get_agent_sources_llm(body.agentId, user, db)
     schema = _build_schema_context(sources)
@@ -110,7 +111,7 @@ async def generate_schema_docs(body: ToolRequest, user: User = Depends(require_u
 # ---------------------------------------------------------------------------
 
 @router.post("/quality-tests")
-async def generate_quality_tests(body: ToolRequest, user: User = Depends(require_user), db: AsyncSession = Depends(get_db)):
+async def generate_quality_tests(body: ToolRequest, scope: TenantScope = Depends(require_membership), db: AsyncSession = Depends(get_db)):
     """Generate data quality tests in multiple formats (dbt, SQL, Great Expectations)."""
     agent, sources, llm = await _get_agent_sources_llm(body.agentId, user, db)
     schema = _build_schema_context(sources)
@@ -133,7 +134,7 @@ async def generate_quality_tests(body: ToolRequest, user: User = Depends(require
 # ---------------------------------------------------------------------------
 
 @router.post("/erd")
-async def generate_erd(body: ToolRequest, user: User = Depends(require_user), db: AsyncSession = Depends(get_db)):
+async def generate_erd(body: ToolRequest, scope: TenantScope = Depends(require_membership), db: AsyncSession = Depends(get_db)):
     """Auto-detect relationships and generate ERD in Mermaid format."""
     agent, sources, llm = await _get_agent_sources_llm(body.agentId, user, db)
     schema = _build_schema_context(sources)
@@ -157,7 +158,7 @@ async def generate_erd(body: ToolRequest, user: User = Depends(require_user), db
 # ---------------------------------------------------------------------------
 
 @router.post("/query-analysis")
-async def analyze_query(body: ToolRequest, user: User = Depends(require_user), db: AsyncSession = Depends(get_db)):
+async def analyze_query(body: ToolRequest, scope: TenantScope = Depends(require_membership), db: AsyncSession = Depends(get_db)):
     """Analyze SQL for performance issues and suggest optimizations."""
     agent, sources, llm = await _get_agent_sources_llm(body.agentId, user, db)
     schema = _build_schema_context(sources)
@@ -186,7 +187,7 @@ async def analyze_query(body: ToolRequest, user: User = Depends(require_user), d
 # ---------------------------------------------------------------------------
 
 @router.post("/transformation-mapping")
-async def suggest_transformation_mapping(body: ToolRequest, user: User = Depends(require_user), db: AsyncSession = Depends(get_db)):
+async def suggest_transformation_mapping(body: ToolRequest, scope: TenantScope = Depends(require_membership), db: AsyncSession = Depends(get_db)):
     """Suggest column-by-column mapping between source and target schemas."""
     agent, sources, llm = await _get_agent_sources_llm(body.agentId, user, db)
     schema = _build_schema_context(sources)
@@ -217,7 +218,7 @@ async def suggest_transformation_mapping(body: ToolRequest, user: User = Depends
 # ---------------------------------------------------------------------------
 
 @router.post("/incremental-strategy")
-async def suggest_incremental_strategy(body: ToolRequest, user: User = Depends(require_user), db: AsyncSession = Depends(get_db)):
+async def suggest_incremental_strategy(body: ToolRequest, scope: TenantScope = Depends(require_membership), db: AsyncSession = Depends(get_db)):
     """Recommend incremental loading strategy based on data profiling."""
     agent, sources, llm = await _get_agent_sources_llm(body.agentId, user, db)
     schema = _build_schema_context(sources)
@@ -246,7 +247,7 @@ async def suggest_incremental_strategy(body: ToolRequest, user: User = Depends(r
 # ---------------------------------------------------------------------------
 
 @router.post("/etl-docs")
-async def reverse_engineer_etl_docs(body: ToolRequest, user: User = Depends(require_user), db: AsyncSession = Depends(get_db)):
+async def reverse_engineer_etl_docs(body: ToolRequest, scope: TenantScope = Depends(require_membership), db: AsyncSession = Depends(get_db)):
     """Generate natural language documentation from SQL code."""
     agent, sources, llm = await _get_agent_sources_llm(body.agentId, user, db)
     schema = _build_schema_context(sources)
@@ -275,7 +276,7 @@ async def reverse_engineer_etl_docs(body: ToolRequest, user: User = Depends(requ
 # ---------------------------------------------------------------------------
 
 @router.post("/catalog")
-async def generate_catalog(body: ToolRequest, user: User = Depends(require_user), db: AsyncSession = Depends(get_db)):
+async def generate_catalog(body: ToolRequest, scope: TenantScope = Depends(require_membership), db: AsyncSession = Depends(get_db)):
     """Generate a data catalog with lineage graph."""
     agent, sources, llm = await _get_agent_sources_llm(body.agentId, user, db)
     schema = _build_schema_context(sources)

--- a/backend/app/routers/dbt_router.py
+++ b/backend/app/routers/dbt_router.py
@@ -8,7 +8,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.database import get_db
 from app.models import Source, User
 from app.routers.crud import _sanitize_for_json
@@ -19,7 +20,7 @@ router = APIRouter(prefix="/dbt", tags=["dbt"])
 @router.post("/validate-manifest")
 async def validate_manifest(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """
     Validate dbt credentials and return list of models from manifest.json.
@@ -81,7 +82,7 @@ async def validate_manifest(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Re-fetch manifest and update table_infos for the source."""
     from app.scripts.ask_dbt import (
@@ -90,7 +91,7 @@ async def refresh_source_metadata(
         _extract_table_infos_from_manifest,
     )
 
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/etl_router.py
+++ b/backend/app/routers/etl_router.py
@@ -7,7 +7,8 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.database import get_db
 from app.models import User, Agent, Source, LlmConfig
 from app.services import etl_service
@@ -28,7 +29,7 @@ class TransformRequest(BaseModel):
 
 
 async def _get_agent_and_llm(agent_id: str, user: User, db: AsyncSession):
-    r = await db.execute(select(Agent).where(Agent.id == agent_id, Agent.user_id == user.id))
+    r = await db.execute(select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Workspace not found")
@@ -47,14 +48,14 @@ async def _get_agent_and_llm(agent_id: str, user: User, db: AsyncSession):
 @router.post("/pipeline/suggest")
 async def suggest_pipeline(
     body: PipelineRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """AI suggests a full ETL pipeline based on sources and description."""
     agent, llm_overrides = await _get_agent_and_llm(body.agentId, user, db)
 
     r = await db.execute(
-        select(Source).where(Source.agent_id == agent.id, Source.user_id == user.id)
+        select(Source).where(Source.agent_id == agent.id, tenant_filter(Source, scope))
     )
     sources = list(r.scalars().all())
     if not sources:
@@ -83,14 +84,14 @@ async def suggest_pipeline(
 @router.post("/transform/suggest")
 async def suggest_transform(
     body: TransformRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """AI generates a single SQL transform."""
     agent, llm_overrides = await _get_agent_and_llm(body.agentId, user, db)
 
     r = await db.execute(
-        select(Source).where(Source.agent_id == agent.id, Source.user_id == user.id)
+        select(Source).where(Source.agent_id == agent.id, tenant_filter(Source, scope))
     )
     sources = list(r.scalars().all())
 
@@ -108,11 +109,11 @@ async def suggest_transform(
 @router.get("/pipelines/{agent_id}")
 async def list_pipelines(
     agent_id: str,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """List all pipelines for a workspace."""
-    r = await db.execute(select(Agent).where(Agent.id == agent_id, Agent.user_id == user.id))
+    r = await db.execute(select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Workspace not found")
@@ -123,11 +124,11 @@ async def list_pipelines(
 @router.get("/lineage/{agent_id}")
 async def get_lineage(
     agent_id: str,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """Get the lineage graph for all pipelines in a workspace."""
-    r = await db.execute(select(Agent).where(Agent.id == agent_id, Agent.user_id == user.id))
+    r = await db.execute(select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Workspace not found")
@@ -157,11 +158,11 @@ async def get_lineage(
 async def delete_pipeline(
     agent_id: str,
     pipeline_id: str,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     """Delete a pipeline from workspace config."""
-    r = await db.execute(select(Agent).where(Agent.id == agent_id, Agent.user_id == user.id))
+    r = await db.execute(select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Workspace not found")

--- a/backend/app/routers/excel_online_router.py
+++ b/backend/app/routers/excel_online_router.py
@@ -8,7 +8,8 @@ The frontend sends the access_token after completing the flow.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -22,7 +23,7 @@ router = APIRouter(prefix="/excel-online", tags=["excel-online"])
 @router.post("/files")
 async def list_files(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List Excel files from OneDrive. Body: { "accessToken": "..." }."""
     access_token = body.get("accessToken")
@@ -45,7 +46,7 @@ async def list_files(
 @router.post("/sheets")
 async def list_sheets(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List worksheets in an Excel file. Body: { "accessToken", "driveId", "itemId" }."""
     access_token = body.get("accessToken")
@@ -71,11 +72,11 @@ async def list_sheets(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Fetch sheet data and update source metadata."""
     r = await db.execute(
-        select(Source).where(Source.id == source_id, Source.user_id == user.id)
+        select(Source).where(Source.id == source_id, tenant_filter(Source, scope))
     )
     source = r.scalar_one_or_none()
     if not source:

--- a/backend/app/routers/firebase_router.py
+++ b/backend/app/routers/firebase_router.py
@@ -6,7 +6,8 @@ Firebase/Firestore discovery and source metadata refresh.
 import asyncio
 import json
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db, AsyncSessionLocal
 from sqlalchemy import select
@@ -20,7 +21,7 @@ router = APIRouter(prefix="/firebase", tags=["firebase"])
 @router.post("/collections")
 async def list_collections(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List top-level Firestore collections. Body: { "credentialsContent": "..." } or { "sourceId": "..." }."""
     credentials_content = body.get("credentialsContent") or body.get("credentials_content")
@@ -28,7 +29,7 @@ async def list_collections(
 
     if source_id and not credentials_content:
         async with AsyncSessionLocal() as db:
-            r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+            r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
             source = r.scalar_one_or_none()
             if not source or source.type != "firebase":
                 raise HTTPException(404, "Firebase source not found")
@@ -55,10 +56,10 @@ async def list_collections(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Fetch Firestore collection schema (field names + preview docs) and update source metadata."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/ga4_router.py
+++ b/backend/app/routers/ga4_router.py
@@ -4,7 +4,8 @@ Google Analytics 4 (GA4) router: test connection, discover tables, refresh metad
 import asyncio
 import json
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db, AsyncSessionLocal
 from sqlalchemy import select
@@ -18,7 +19,7 @@ router = APIRouter(prefix="/ga4", tags=["ga4"])
 @router.post("/test-connection")
 async def test_connection(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Test GA4 connection by running a minimal report.
     Body: { "credentialsContent": "...", "propertyId": "..." }
@@ -57,7 +58,7 @@ async def test_connection(
 @router.post("/discover")
 async def discover_tables(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Discover GA4 tables (fetch sample data for each).
     Body: { "credentialsContent": "...", "propertyId": "...", "tables": [...] (optional) }
@@ -85,10 +86,10 @@ async def discover_tables(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Refresh GA4 source metadata (re-fetch table schemas and preview data)."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/github_analytics_router.py
+++ b/backend/app/routers/github_analytics_router.py
@@ -6,7 +6,8 @@ GitHub Analytics discovery and source metadata refresh.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -20,7 +21,7 @@ router = APIRouter(prefix="/github-analytics", tags=["github_analytics"])
 @router.post("/test-connection")
 async def test_connection(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Test a GitHub token and repo access. Body: { "token": "...", "owner": "...", "repo": "..." }."""
     token = body.get("token")
@@ -46,7 +47,7 @@ async def test_connection(
 @router.post("/discover")
 async def discover_resources(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Discover GitHub repo resources. Body: { "token": "...", "owner": "...", "repo": "..." }."""
     token = body.get("token")
@@ -74,11 +75,11 @@ async def discover_resources(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Fetch GitHub data and update source metadata with schema and preview."""
     r = await db.execute(
-        select(Source).where(Source.id == source_id, Source.user_id == user.id)
+        select(Source).where(Source.id == source_id, tenant_filter(Source, scope))
     )
     source = r.scalar_one_or_none()
     if not source:

--- a/backend/app/routers/github_router.py
+++ b/backend/app/routers/github_router.py
@@ -9,7 +9,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.database import get_db
 from app.models import Source, User
 from app.routers.crud import _sanitize_for_json
@@ -22,7 +23,7 @@ _SUPPORTED_EXTENSIONS = {".csv", ".tsv", ".json", ".jsonl", ".ndjson"}
 @router.post("/validate")
 async def validate_github_file(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """
     Validate access to a GitHub repo file and return columns + preview rows.
@@ -64,7 +65,7 @@ async def validate_github_file(
 @router.post("/list-files")
 async def list_github_files(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """
     List data files (CSV/TSV/JSON) in a repository directory.
@@ -114,12 +115,12 @@ async def list_github_files(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Re-download the file and update columns + preview_rows for the source."""
     from app.scripts.ask_github_file import _download_github_file, _parse_file_content
 
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/hubspot_router.py
+++ b/backend/app/routers/hubspot_router.py
@@ -3,7 +3,8 @@ HubSpot CRM discovery and connection testing.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -14,7 +15,7 @@ router = APIRouter(prefix="/hubspot", tags=["hubspot"])
 
 
 @router.post("/test-connection")
-async def test_connection(body: dict, user: User = Depends(require_user)):
+async def test_connection(body: dict, scope: TenantScope = Depends(require_membership)):
     """Test HubSpot API connection with the provided API key."""
     api_key = body.get("apiKey", "")
     if not api_key:
@@ -30,7 +31,7 @@ async def test_connection(body: dict, user: User = Depends(require_user)):
 
 
 @router.post("/discover")
-async def discover_objects(body: dict, user: User = Depends(require_user)):
+async def discover_objects(body: dict, scope: TenantScope = Depends(require_membership)):
     """Discover available HubSpot CRM objects and their counts."""
     api_key = body.get("apiKey", "")
     if not api_key:
@@ -47,9 +48,9 @@ async def discover_objects(body: dict, user: User = Depends(require_user)):
 
 @router.post("/sources/{source_id}/refresh-metadata")
 async def refresh_source_metadata(
-    source_id: str, db: AsyncSession = Depends(get_db), user: User = Depends(require_user),
+    source_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/intercom_router.py
+++ b/backend/app/routers/intercom_router.py
@@ -6,7 +6,8 @@ Intercom integration: test connection, discover resources, refresh metadata.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -20,7 +21,7 @@ router = APIRouter(prefix="/intercom", tags=["intercom"])
 @router.post("/test-connection")
 async def test_connection(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Test an Intercom access token. Body: { "accessToken": "..." }."""
     token = body.get("accessToken")
@@ -40,7 +41,7 @@ async def test_connection(
 @router.post("/discover")
 async def discover_resources(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Discover available Intercom resources. Body: { "accessToken": "..." }."""
     token = body.get("accessToken")
@@ -64,11 +65,11 @@ async def discover_resources(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Fetch Intercom resource schemas and preview data, update source metadata."""
     r = await db.execute(
-        select(Source).where(Source.id == source_id, Source.user_id == user.id)
+        select(Source).where(Source.id == source_id, tenant_filter(Source, scope))
     )
     source = r.scalar_one_or_none()
     if not source:

--- a/backend/app/routers/jira_router.py
+++ b/backend/app/routers/jira_router.py
@@ -3,7 +3,8 @@ Jira integration: test connection, discover projects/boards, refresh source meta
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -17,7 +18,7 @@ router = APIRouter(prefix="/jira", tags=["jira"])
 @router.post("/test-connection")
 async def test_connection(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Test Jira credentials. Body: { "domain": "...", "email": "...", "apiToken": "..." }."""
     domain = body.get("domain")
@@ -41,7 +42,7 @@ async def test_connection(
 @router.post("/discover")
 async def discover(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Discover Jira projects and boards. Body: { "domain": "...", "email": "...", "apiToken": "..." }."""
     domain = body.get("domain")
@@ -66,11 +67,11 @@ async def discover(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Refresh Jira source metadata: re-discover projects and boards."""
     r = await db.execute(
-        select(Source).where(Source.id == source_id, Source.user_id == user.id)
+        select(Source).where(Source.id == source_id, tenant_filter(Source, scope))
     )
     source = r.scalar_one_or_none()
     if not source:

--- a/backend/app/routers/medallion_router.py
+++ b/backend/app/routers/medallion_router.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
 from app.config import get_settings
 from app.database import get_db
 from app.models import (
@@ -25,9 +25,9 @@ router = APIRouter(prefix="/medallion", tags=["medallion"])
 # Helpers
 # ---------------------------------------------------------------------------
 
-async def _get_source(source_id: str, user_id: str, db: AsyncSession) -> Source:
+async def _get_source(source_id: str, scope: TenantScope, db: AsyncSession) -> Source:
     result = await db.execute(
-        select(Source).where(Source.id == source_id, Source.user_id == user_id)
+        select(Source).where(Source.id == source_id, tenant_filter(Source, scope))
     )
     source = result.scalar_one_or_none()
     if not source:
@@ -35,12 +35,16 @@ async def _get_source(source_id: str, user_id: str, db: AsyncSession) -> Source:
     return source
 
 
-async def _resolve_llm_overrides(agent_id: str, user_id: str, db: AsyncSession) -> dict | None:
+async def _resolve_llm_overrides(
+    agent_id: str, scope: TenantScope, db: AsyncSession
+) -> dict | None:
     """Load LLM config for the agent's user, following the same logic as ask.py."""
     from app.routers.ask import _llm_config_to_overrides
 
     # Try agent-specific config
-    result = await db.execute(select(Agent).where(Agent.id == agent_id))
+    result = await db.execute(
+        select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope))
+    )
     agent = result.scalar_one_or_none()
     if agent and agent.llm_config_id:
         cfg_result = await db.execute(
@@ -52,7 +56,7 @@ async def _resolve_llm_overrides(agent_id: str, user_id: str, db: AsyncSession) 
 
     # Fallback to user default LlmSettings
     settings_result = await db.execute(
-        select(LlmSettings).where(LlmSettings.user_id == user_id)
+        select(LlmSettings).where(LlmSettings.user_id == scope.user.id)
     )
     settings = settings_result.scalar_one_or_none()
     return _llm_config_to_overrides(settings)
@@ -74,13 +78,13 @@ def _log_out(d: dict) -> dict:
 @router.get("/sources/{source_id}/layers")
 async def list_layers(
     source_id: str,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
-    await _get_source(source_id, user.id, db)
+    await _get_source(source_id, scope, db)
     result = await db.execute(
         select(MedallionLayer)
-        .where(MedallionLayer.source_id == source_id, MedallionLayer.user_id == user.id)
+        .where(MedallionLayer.source_id == source_id, MedallionLayer.user_id == scope.user.id)
         .order_by(MedallionLayer.created_at)
     )
     layers = result.scalars().all()
@@ -90,13 +94,13 @@ async def list_layers(
 @router.get("/sources/{source_id}/logs")
 async def list_logs(
     source_id: str,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
-    await _get_source(source_id, user.id, db)
+    await _get_source(source_id, scope, db)
     result = await db.execute(
         select(MedallionBuildLog)
-        .where(MedallionBuildLog.source_id == source_id, MedallionBuildLog.user_id == user.id)
+        .where(MedallionBuildLog.source_id == source_id, MedallionBuildLog.user_id == scope.user.id)
         .order_by(MedallionBuildLog.created_at.desc())
     )
     logs = result.scalars().all()
@@ -106,12 +110,12 @@ async def list_logs(
 @router.get("/layers/{layer_id}")
 async def get_layer(
     layer_id: str,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(
         select(MedallionLayer).where(
-            MedallionLayer.id == layer_id, MedallionLayer.user_id == user.id
+            MedallionLayer.id == layer_id, MedallionLayer.user_id == scope.user.id
         )
     )
     layer = result.scalar_one_or_none()
@@ -127,14 +131,14 @@ async def get_layer(
 @router.post("/bronze/generate")
 async def generate_bronze(
     body: BronzeGenerateRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
-    source = await _get_source(body.sourceId, user.id, db)
+    source = await _get_source(body.sourceId, scope, db)
     settings = get_settings()
     try:
         layer = await svc.generate_bronze(
-            source, user.id, body.agentId, settings.data_files_dir, db
+            source, scope.user.id, body.agentId, settings.data_files_dir, db
         )
         return layer
     except Exception as e:
@@ -148,15 +152,15 @@ async def generate_bronze(
 @router.post("/silver/suggest")
 async def suggest_silver(
     body: SilverSuggestRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
-    source = await _get_source(body.sourceId, user.id, db)
+    source = await _get_source(body.sourceId, scope, db)
     settings = get_settings()
-    llm_overrides = await _resolve_llm_overrides(body.agentId, user.id, db)
+    llm_overrides = await _resolve_llm_overrides(body.agentId, scope, db)
     try:
         result = await svc.suggest_silver(
-            source, user.id, body.agentId, settings.data_files_dir, db,
+            source, scope.user.id, body.agentId, settings.data_files_dir, db,
             llm_overrides=llm_overrides,
             feedback=body.feedback,
         )
@@ -168,14 +172,14 @@ async def suggest_silver(
 @router.post("/silver/apply")
 async def apply_silver(
     body: SilverApplyRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
-    source = await _get_source(body.sourceId, user.id, db)
+    source = await _get_source(body.sourceId, scope, db)
     settings = get_settings()
     try:
         layer = await svc.apply_silver(
-            source, user.id, body.agentId, settings.data_files_dir, db,
+            source, scope.user.id, body.agentId, settings.data_files_dir, db,
             build_log_id=body.buildLogId,
             config=body.config,
         )
@@ -191,15 +195,15 @@ async def apply_silver(
 @router.post("/gold/suggest")
 async def suggest_gold(
     body: GoldSuggestRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
-    source = await _get_source(body.sourceId, user.id, db)
+    source = await _get_source(body.sourceId, scope, db)
     settings = get_settings()
-    llm_overrides = await _resolve_llm_overrides(body.agentId, user.id, db)
+    llm_overrides = await _resolve_llm_overrides(body.agentId, scope, db)
     try:
         result = await svc.suggest_gold(
-            source, user.id, body.agentId, settings.data_files_dir, db,
+            source, scope.user.id, body.agentId, settings.data_files_dir, db,
             llm_overrides=llm_overrides,
             feedback=body.feedback,
             report_prompt=body.reportPrompt,
@@ -212,14 +216,14 @@ async def suggest_gold(
 @router.post("/gold/apply")
 async def apply_gold(
     body: GoldApplyRequest,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
-    source = await _get_source(body.sourceId, user.id, db)
+    source = await _get_source(body.sourceId, scope, db)
     settings = get_settings()
     try:
         layers = await svc.apply_gold(
-            source, user.id, body.agentId, settings.data_files_dir, db,
+            source, scope.user.id, body.agentId, settings.data_files_dir, db,
             build_log_id=body.buildLogId,
             selected_tables=body.selectedTables,
         )
@@ -235,12 +239,12 @@ async def apply_gold(
 @router.delete("/layers/{layer_id}")
 async def delete_layer(
     layer_id: str,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
     db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(
         select(MedallionLayer).where(
-            MedallionLayer.id == layer_id, MedallionLayer.user_id == user.id
+            MedallionLayer.id == layer_id, MedallionLayer.user_id == scope.user.id
         )
     )
     layer = result.scalar_one_or_none()

--- a/backend/app/routers/mongodb_router.py
+++ b/backend/app/routers/mongodb_router.py
@@ -7,7 +7,8 @@ MongoDB discovery and source metadata refresh.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db, AsyncSessionLocal
 from sqlalchemy import select
@@ -21,7 +22,7 @@ router = APIRouter(prefix="/mongodb", tags=["mongodb"])
 @router.post("/test-connection")
 async def test_connection(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Test a MongoDB connection string. Body: { "connectionString": "..." }."""
     connection_string = body.get("connectionString")
@@ -43,7 +44,7 @@ async def test_connection(
 @router.post("/databases")
 async def list_databases(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List available MongoDB databases. Body: { "connectionString": "..." }."""
     connection_string = body.get("connectionString")
@@ -66,7 +67,7 @@ async def list_databases(
 @router.post("/collections")
 async def list_collections(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List collections in a MongoDB database. Body: { "connectionString": "...", "database": "..." }."""
     connection_string = body.get("connectionString")
@@ -91,11 +92,11 @@ async def list_collections(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Fetch MongoDB collection schema (fields + preview) and update source metadata."""
     r = await db.execute(
-        select(Source).where(Source.id == source_id, Source.user_id == user.id)
+        select(Source).where(Source.id == source_id, tenant_filter(Source, scope))
     )
     source = r.scalar_one_or_none()
     if not source:

--- a/backend/app/routers/notion_router.py
+++ b/backend/app/routers/notion_router.py
@@ -6,7 +6,8 @@ Notion Database discovery and source metadata refresh.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -20,7 +21,7 @@ router = APIRouter(prefix="/notion", tags=["notion"])
 @router.post("/test-connection")
 async def test_connection(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Test a Notion integration token. Body: { "integrationToken": "..." }."""
     token = body.get("integrationToken")
@@ -40,7 +41,7 @@ async def test_connection(
 @router.post("/databases")
 async def list_databases(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List accessible Notion databases. Body: { "integrationToken": "..." }."""
     token = body.get("integrationToken")
@@ -64,11 +65,11 @@ async def list_databases(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Fetch Notion database properties and preview rows, update source metadata."""
     r = await db.execute(
-        select(Source).where(Source.id == source_id, Source.user_id == user.id)
+        select(Source).where(Source.id == source_id, tenant_filter(Source, scope))
     )
     source = r.scalar_one_or_none()
     if not source:

--- a/backend/app/routers/organizations_router.py
+++ b/backend/app/routers/organizations_router.py
@@ -1,0 +1,315 @@
+"""Organization management endpoints.
+
+Scope: list the caller's organizations, list members of an org, add an
+existing user as a member, change a member's role, and remove a member.
+Invites are intentionally out of scope — the product choice in this PR is
+"add an existing registered user directly" rather than an email-based
+invite flow. Opens the door for an invite model without breaking these
+endpoints.
+
+Role rules:
+- list orgs:              any member
+- list/add/update/remove: admin or owner (per `require_role("admin")`)
+- last-owner safety:      the server refuses to remove or demote the
+                          only remaining `owner`, regardless of caller
+                          role. This prevents locking an org out
+                          entirely.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, EmailStr
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import (
+    ROLE_HIERARCHY,
+    TenantScope,
+    require_membership,
+    require_role,
+)
+from app.database import get_db
+from app.models import Organization, OrganizationMembership, User, VALID_ROLES
+
+
+router = APIRouter(prefix="/organizations", tags=["organizations"])
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+
+@router.get("")
+async def list_my_organizations(
+    scope: TenantScope = Depends(require_membership),
+    db: AsyncSession = Depends(get_db),
+) -> list[dict]:
+    """List organizations the caller belongs to, with their role in each."""
+    r = await db.execute(
+        select(OrganizationMembership, Organization)
+        .join(Organization, Organization.id == OrganizationMembership.organization_id)
+        .where(OrganizationMembership.user_id == scope.user.id)
+        .order_by(OrganizationMembership.created_at.asc())
+    )
+    return [
+        {
+            "id": org.id,
+            "name": org.name,
+            "slug": org.slug,
+            "role": m.role,
+            "is_active": scope.organization_id == org.id,
+            "created_at": org.created_at.isoformat() if org.created_at else None,
+        }
+        for m, org in r.all()
+    ]
+
+
+async def _ensure_caller_can_manage(
+    db: AsyncSession, scope: TenantScope, organization_id: str
+) -> None:
+    """Manage = read members + write membership.
+
+    The caller's scope org must match the path's organization_id, and their
+    role there must be admin or owner. `require_role("admin")` gates the
+    role; we separately enforce that `scope.organization_id == org_id` so a
+    caller can't mutate an org they're not actively scoped to.
+    """
+    if scope.organization_id != organization_id:
+        raise HTTPException(
+            403,
+            "Switch to this organization via POST /api/auth/switch-org before managing it.",
+        )
+
+
+@router.get("/{organization_id}/members")
+async def list_members(
+    organization_id: str,
+    scope: TenantScope = Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+) -> list[dict]:
+    await _ensure_caller_can_manage(db, scope, organization_id)
+    r = await db.execute(
+        select(OrganizationMembership, User)
+        .join(User, User.id == OrganizationMembership.user_id)
+        .where(OrganizationMembership.organization_id == organization_id)
+        .order_by(OrganizationMembership.created_at.asc())
+    )
+    return [
+        {
+            "user_id": u.id,
+            "email": u.email,
+            "role": m.role,
+            "joined_at": m.created_at.isoformat() if m.created_at else None,
+        }
+        for m, u in r.all()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Write
+# ---------------------------------------------------------------------------
+
+
+class AddMemberBody(BaseModel):
+    email: EmailStr
+    role: str = "member"
+
+
+@router.post("/{organization_id}/members")
+async def add_member(
+    organization_id: str,
+    body: AddMemberBody,
+    scope: TenantScope = Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    await _ensure_caller_can_manage(db, scope, organization_id)
+    if body.role not in VALID_ROLES:
+        raise HTTPException(400, f"role must be one of: {', '.join(VALID_ROLES)}")
+    # Only owners can create other owners. Admins can add admin/member/viewer.
+    if body.role == "owner" and scope.role != "owner":
+        raise HTTPException(403, "Only owners can grant the owner role.")
+
+    r = await db.execute(select(User).where(User.email == body.email))
+    user = r.scalar_one_or_none()
+    if not user:
+        raise HTTPException(
+            404,
+            f"No registered user with email {body.email}. The user must sign up first "
+            "before you can add them to the organization.",
+        )
+
+    r = await db.execute(
+        select(OrganizationMembership).where(
+            OrganizationMembership.organization_id == organization_id,
+            OrganizationMembership.user_id == user.id,
+        )
+    )
+    if r.scalar_one_or_none():
+        raise HTTPException(409, "User is already a member of this organization.")
+
+    m = OrganizationMembership(
+        id=str(uuid.uuid4()),
+        organization_id=organization_id,
+        user_id=user.id,
+        role=body.role,
+    )
+    db.add(m)
+    await db.commit()
+    return {
+        "user_id": user.id,
+        "email": user.email,
+        "role": body.role,
+    }
+
+
+class UpdateRoleBody(BaseModel):
+    role: str
+
+
+async def _count_owners(db: AsyncSession, organization_id: str) -> int:
+    r = await db.execute(
+        select(OrganizationMembership).where(
+            OrganizationMembership.organization_id == organization_id,
+            OrganizationMembership.role == "owner",
+        )
+    )
+    return len(list(r.scalars().all()))
+
+
+@router.patch("/{organization_id}/members/{user_id}")
+async def update_member_role(
+    organization_id: str,
+    user_id: str,
+    body: UpdateRoleBody,
+    scope: TenantScope = Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    await _ensure_caller_can_manage(db, scope, organization_id)
+    if body.role not in VALID_ROLES:
+        raise HTTPException(400, f"role must be one of: {', '.join(VALID_ROLES)}")
+
+    # Only owners can promote to or demote from owner.
+    if body.role == "owner" and scope.role != "owner":
+        raise HTTPException(403, "Only owners can grant the owner role.")
+
+    r = await db.execute(
+        select(OrganizationMembership).where(
+            OrganizationMembership.organization_id == organization_id,
+            OrganizationMembership.user_id == user_id,
+        )
+    )
+    m = r.scalar_one_or_none()
+    if not m:
+        raise HTTPException(404, "Member not found")
+
+    if m.role == "owner" and body.role != "owner":
+        # Demoting last owner is refused.
+        if await _count_owners(db, organization_id) <= 1:
+            raise HTTPException(
+                400, "Cannot demote the last owner of the organization."
+            )
+        if scope.role != "owner":
+            raise HTTPException(403, "Only owners can demote an owner.")
+
+    m.role = body.role
+    await db.commit()
+    return {"user_id": user_id, "role": body.role}
+
+
+@router.delete("/{organization_id}/members/{user_id}")
+async def remove_member(
+    organization_id: str,
+    user_id: str,
+    scope: TenantScope = Depends(require_role("admin")),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    await _ensure_caller_can_manage(db, scope, organization_id)
+    r = await db.execute(
+        select(OrganizationMembership).where(
+            OrganizationMembership.organization_id == organization_id,
+            OrganizationMembership.user_id == user_id,
+        )
+    )
+    m = r.scalar_one_or_none()
+    if not m:
+        raise HTTPException(404, "Member not found")
+
+    if m.role == "owner":
+        if await _count_owners(db, organization_id) <= 1:
+            raise HTTPException(
+                400, "Cannot remove the last owner of the organization."
+            )
+        if scope.role != "owner":
+            raise HTTPException(403, "Only owners can remove an owner.")
+
+    # A non-owner caller is allowed to remove themselves (leave the org)
+    # but that's out of scope for this endpoint — use a dedicated
+    # /leave action in the future if desired. For now, same gate.
+    await db.delete(m)
+    await db.commit()
+    return {"ok": True, "user_id": user_id}
+
+
+# ---------------------------------------------------------------------------
+# Create org (every authenticated user can create their own)
+# ---------------------------------------------------------------------------
+
+
+class CreateOrgBody(BaseModel):
+    name: str
+    slug: Optional[str] = None
+
+
+def _slugify(text: str) -> str:
+    import re
+
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", (text or "").lower()).strip("-")
+    return slug or "organization"
+
+
+@router.post("")
+async def create_organization(
+    body: CreateOrgBody,
+    scope: TenantScope = Depends(require_membership),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Anyone authenticated can create an organization; they become its owner."""
+    base_slug = _slugify(body.slug or body.name)
+    slug = base_slug
+    suffix = 2
+    while True:
+        r = await db.execute(select(Organization.id).where(Organization.slug == slug))
+        if not r.scalar_one_or_none():
+            break
+        slug = f"{base_slug}-{suffix}"
+        suffix += 1
+
+    org = Organization(
+        id=str(uuid.uuid4()),
+        name=body.name,
+        slug=slug,
+        created_by=scope.user.id,
+    )
+    db.add(org)
+    await db.flush()
+
+    membership = OrganizationMembership(
+        id=str(uuid.uuid4()),
+        organization_id=org.id,
+        user_id=scope.user.id,
+        role="owner",
+    )
+    db.add(membership)
+    await db.commit()
+
+    return {
+        "id": org.id,
+        "name": org.name,
+        "slug": org.slug,
+        "role": "owner",
+        "created_at": org.created_at.isoformat() if org.created_at else None,
+    }

--- a/backend/app/routers/pipedrive_router.py
+++ b/backend/app/routers/pipedrive_router.py
@@ -3,7 +3,8 @@ Pipedrive CRM discovery and connection testing.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -14,7 +15,7 @@ router = APIRouter(prefix="/pipedrive", tags=["pipedrive"])
 
 
 @router.post("/test-connection")
-async def test_connection(body: dict, user: User = Depends(require_user)):
+async def test_connection(body: dict, scope: TenantScope = Depends(require_membership)):
     """Test Pipedrive API connection."""
     api_token = body.get("apiToken", "")
     if not api_token:
@@ -30,7 +31,7 @@ async def test_connection(body: dict, user: User = Depends(require_user)):
 
 
 @router.post("/discover")
-async def discover_resources(body: dict, user: User = Depends(require_user)):
+async def discover_resources(body: dict, scope: TenantScope = Depends(require_membership)):
     """Discover available Pipedrive resources and their counts."""
     api_token = body.get("apiToken", "")
     if not api_token:
@@ -47,9 +48,9 @@ async def discover_resources(body: dict, user: User = Depends(require_user)):
 
 @router.post("/sources/{source_id}/refresh-metadata")
 async def refresh_source_metadata(
-    source_id: str, db: AsyncSession = Depends(get_db), user: User = Depends(require_user),
+    source_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/pipeline_runs_router.py
+++ b/backend/app/routers/pipeline_runs_router.py
@@ -93,7 +93,7 @@ async def get_run(
         raise HTTPException(404, "Run not found")
 
     r2 = await db.execute(
-        select(LineageEdge).where(LineageEdge.run_id == run_id).order_by(LineageEdge.created_at)
+        select(LineageEdge).where(LineageEdge.run_id == run_id, tenant_filter(LineageEdge, scope)).order_by(LineageEdge.created_at)
     )
     edges = list(r2.scalars().all())
     return {
@@ -121,7 +121,7 @@ async def agent_lineage(
     if not run_ids:
         return {"nodes": [], "edges": []}
 
-    edges_q = select(LineageEdge).where(LineageEdge.run_id.in_(run_ids))
+    edges_q = select(LineageEdge).where(LineageEdge.run_id.in_(run_ids), tenant_filter(LineageEdge, scope))
     r2 = await db.execute(edges_q)
     edges = list(r2.scalars().all())
     return build_lineage_graph(edges)

--- a/backend/app/routers/report_router.py
+++ b/backend/app/routers/report_router.py
@@ -11,7 +11,8 @@ from typing import Optional
 
 from app.database import get_db
 from app.models import User, Agent, Source, Report, LlmSettings, LlmConfig
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.config import get_settings
 from app.scripts.report_csv import generate_report_csv
 from app.scripts.report_bigquery import generate_report_bigquery
@@ -79,25 +80,25 @@ class GenerateReportRequest(BaseModel):
 async def generate_report(
     body: GenerateReportRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Generate a rich HTML report with exploratory charts for the selected source."""
-    r = await db.execute(select(Agent).where(Agent.id == body.agentId))
+    r = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Agent not found")
 
     # Resolve source
     if body.sourceId:
-        r = await db.execute(select(Source).where(Source.id == body.sourceId, Source.user_id == user.id))
+        r = await db.execute(select(Source).where(Source.id == body.sourceId, tenant_filter(Source, scope)))
         source = r.scalar_one_or_none()
     else:
         r = await db.execute(
-            select(Source).where(Source.agent_id == body.agentId, Source.user_id == user.id, Source.is_active == True)
+            select(Source).where(Source.agent_id == body.agentId, tenant_filter(Source, scope), Source.is_active == True)
         )
         source = r.scalar_one_or_none()
         if not source:
-            r = await db.execute(select(Source).where(Source.agent_id == body.agentId, Source.user_id == user.id))
+            r = await db.execute(select(Source).where(Source.agent_id == body.agentId, tenant_filter(Source, scope)))
             source = r.scalar_one_or_none()
 
     if not source:
@@ -210,7 +211,7 @@ async def generate_report(
 async def list_reports(
     agent_id: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List reports, optionally filtered by workspace (agent_id)."""
     q = select(Report).where(Report.user_id == user.id).order_by(Report.created_at.desc())
@@ -235,7 +236,7 @@ async def list_reports(
 async def get_report(
     report_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Get a single report by id (metadata only, no HTML content)."""
     r = await db.execute(select(Report).where(Report.id == report_id, Report.user_id == user.id))
@@ -256,7 +257,7 @@ async def get_report(
 async def get_report_html(
     report_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Serve the HTML content of a report (for iframe or download)."""
     r = await db.execute(select(Report).where(Report.id == report_id, Report.user_id == user.id))
@@ -270,7 +271,7 @@ async def get_report_html(
 async def delete_report(
     report_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Delete a report."""
     r = await db.execute(select(Report).where(Report.id == report_id, Report.user_id == user.id))

--- a/backend/app/routers/rest_api_router.py
+++ b/backend/app/routers/rest_api_router.py
@@ -3,7 +3,8 @@ REST API discovery and source metadata refresh.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -14,7 +15,7 @@ router = APIRouter(prefix="/rest-api", tags=["rest-api"])
 
 
 @router.post("/test")
-async def test_request(body: dict, user: User = Depends(require_user)):
+async def test_request(body: dict, scope: TenantScope = Depends(require_membership)):
     """Execute a test API request and return preview. Body: { url, method, headers, queryParams, body, dataPath }."""
     url = body.get("url", "")
     if not url:
@@ -41,9 +42,9 @@ async def test_request(body: dict, user: User = Depends(require_user)):
 
 @router.post("/sources/{source_id}/refresh-metadata")
 async def refresh_source_metadata(
-    source_id: str, db: AsyncSession = Depends(get_db), user: User = Depends(require_user),
+    source_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/s3_router.py
+++ b/backend/app/routers/s3_router.py
@@ -3,7 +3,8 @@ Amazon S3 / MinIO discovery and source metadata refresh.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -25,7 +26,7 @@ def _extract_creds(body: dict) -> tuple[str, str, str, str | None]:
 
 
 @router.post("/test-connection")
-async def test_connection(body: dict, user: User = Depends(require_user)):
+async def test_connection(body: dict, scope: TenantScope = Depends(require_membership)):
     ak, sk, region, endpoint = _extract_creds(body)
     from app.scripts.ask_s3 import _test_connection_sync
     loop = asyncio.get_event_loop()
@@ -37,7 +38,7 @@ async def test_connection(body: dict, user: User = Depends(require_user)):
 
 
 @router.post("/buckets")
-async def list_buckets(body: dict, user: User = Depends(require_user)):
+async def list_buckets(body: dict, scope: TenantScope = Depends(require_membership)):
     ak, sk, region, endpoint = _extract_creds(body)
     from app.scripts.ask_s3 import _list_buckets_sync
     loop = asyncio.get_event_loop()
@@ -49,7 +50,7 @@ async def list_buckets(body: dict, user: User = Depends(require_user)):
 
 
 @router.post("/objects")
-async def list_objects(body: dict, user: User = Depends(require_user)):
+async def list_objects(body: dict, scope: TenantScope = Depends(require_membership)):
     ak, sk, region, endpoint = _extract_creds(body)
     bucket = body.get("bucket", "")
     prefix = body.get("prefix", "")
@@ -68,9 +69,9 @@ async def list_objects(body: dict, user: User = Depends(require_user)):
 
 @router.post("/sources/{source_id}/refresh-metadata")
 async def refresh_source_metadata(
-    source_id: str, db: AsyncSession = Depends(get_db), user: User = Depends(require_user),
+    source_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/salesforce_router.py
+++ b/backend/app/routers/salesforce_router.py
@@ -3,7 +3,8 @@ Salesforce CRM discovery and connection testing.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -14,7 +15,7 @@ router = APIRouter(prefix="/salesforce", tags=["salesforce"])
 
 
 @router.post("/test-connection")
-async def test_connection(body: dict, user: User = Depends(require_user)):
+async def test_connection(body: dict, scope: TenantScope = Depends(require_membership)):
     """Test Salesforce API connection with the provided access token and instance URL."""
     access_token = body.get("accessToken", "")
     instance_url = body.get("instanceUrl", "")
@@ -36,7 +37,7 @@ async def test_connection(body: dict, user: User = Depends(require_user)):
 
 
 @router.post("/discover")
-async def discover_objects(body: dict, user: User = Depends(require_user)):
+async def discover_objects(body: dict, scope: TenantScope = Depends(require_membership)):
     """Discover available Salesforce CRM objects and their counts."""
     access_token = body.get("accessToken", "")
     instance_url = body.get("instanceUrl", "")
@@ -58,9 +59,9 @@ async def discover_objects(body: dict, user: User = Depends(require_user)):
 
 @router.post("/sources/{source_id}/refresh-metadata")
 async def refresh_source_metadata(
-    source_id: str, db: AsyncSession = Depends(get_db), user: User = Depends(require_user),
+    source_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/shopify_router.py
+++ b/backend/app/routers/shopify_router.py
@@ -3,7 +3,8 @@ Shopify store discovery and connection testing.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -14,7 +15,7 @@ router = APIRouter(prefix="/shopify", tags=["shopify"])
 
 
 @router.post("/test-connection")
-async def test_connection(body: dict, user: User = Depends(require_user)):
+async def test_connection(body: dict, scope: TenantScope = Depends(require_membership)):
     """Test Shopify API connection with the provided store name and access token."""
     store = body.get("store", "")
     access_token = body.get("accessToken", "")
@@ -31,7 +32,7 @@ async def test_connection(body: dict, user: User = Depends(require_user)):
 
 
 @router.post("/discover")
-async def discover_objects(body: dict, user: User = Depends(require_user)):
+async def discover_objects(body: dict, scope: TenantScope = Depends(require_membership)):
     """Discover available Shopify resources and their counts."""
     store = body.get("store", "")
     access_token = body.get("accessToken", "")
@@ -49,9 +50,9 @@ async def discover_objects(body: dict, user: User = Depends(require_user)):
 
 @router.post("/sources/{source_id}/refresh-metadata")
 async def refresh_source_metadata(
-    source_id: str, db: AsyncSession = Depends(get_db), user: User = Depends(require_user),
+    source_id: str, db: AsyncSession = Depends(get_db), scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/snowflake_router.py
+++ b/backend/app/routers/snowflake_router.py
@@ -6,7 +6,8 @@ Snowflake discovery and source metadata refresh.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -29,7 +30,7 @@ def _extract_creds(body: dict) -> tuple[str, str, str]:
 @router.post("/test-connection")
 async def test_connection(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Test Snowflake credentials."""
     account, sf_user, password = _extract_creds(body)
@@ -49,7 +50,7 @@ async def test_connection(
 @router.post("/warehouses")
 async def list_warehouses(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List available Snowflake warehouses."""
     account, sf_user, password = _extract_creds(body)
@@ -70,7 +71,7 @@ async def list_warehouses(
 @router.post("/databases")
 async def list_databases(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List available Snowflake databases."""
     account, sf_user, password = _extract_creds(body)
@@ -91,7 +92,7 @@ async def list_databases(
 @router.post("/schemas")
 async def list_schemas(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List schemas in a Snowflake database."""
     account, sf_user, password = _extract_creds(body)
@@ -115,7 +116,7 @@ async def list_schemas(
 @router.post("/tables")
 async def list_tables(
     body: dict,
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List tables in a Snowflake schema."""
     account, sf_user, password = _extract_creds(body)
@@ -141,11 +142,11 @@ async def list_tables(
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Fetch Snowflake table schema and preview rows and update source metadata."""
     r = await db.execute(
-        select(Source).where(Source.id == source_id, Source.user_id == user.id)
+        select(Source).where(Source.id == source_id, tenant_filter(Source, scope))
     )
     source = r.scalar_one_or_none()
     if not source:

--- a/backend/app/routers/sql_router.py
+++ b/backend/app/routers/sql_router.py
@@ -55,7 +55,7 @@ async def _get_agent_sql_sources(
     db: AsyncSession,
     user: User,
 ) -> tuple[Agent, list[Source]]:
-    result = await db.execute(select(Agent).where(Agent.id == agent_id, Agent.user_id == user.id))
+    result = await db.execute(select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope)))
     agent = result.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Agent not found")

--- a/backend/app/routers/sql_router.py
+++ b/backend/app/routers/sql_router.py
@@ -6,7 +6,8 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.database import get_db
 from app.models import Agent, Source, User
 from app.scripts.sql_utils import (
@@ -22,7 +23,7 @@ router = APIRouter(prefix="/sql", tags=["sql"])
 @router.post("/tables")
 async def list_tables(
     body: dict,
-    _user: User = Depends(require_user),
+    _scope: TenantScope = Depends(require_membership),
 ):
     """List tables available for a SQL connection string."""
     connection_string = (body.get("connectionString") or body.get("connection_string") or "").strip()
@@ -62,7 +63,7 @@ async def _get_agent_sql_sources(
     if agent.source_ids:
         source_result = await db.execute(
             select(Source).where(
-                Source.user_id == user.id,
+                tenant_filter(Source, scope),
                 Source.id.in_(agent.source_ids),
                 Source.type == "sql_database",
             )
@@ -70,7 +71,7 @@ async def _get_agent_sql_sources(
     else:
         source_result = await db.execute(
             select(Source).where(
-                Source.user_id == user.id,
+                tenant_filter(Source, scope),
                 Source.agent_id == agent.id,
                 Source.type == "sql_database",
             )
@@ -91,7 +92,7 @@ class DismissSuggestionBody(BaseModel):
 async def list_agent_sql_sources(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     agent, sources = await _get_agent_sql_sources(agent_id, db, user)
     source_rows = [_source_sql_payload(source) for source in sources]
@@ -113,7 +114,7 @@ async def list_agent_sql_sources(
 async def list_relationship_suggestions(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     agent, sources = await _get_agent_sql_sources(agent_id, db, user)
     source_rows = [_source_sql_payload(source) for source in sources]
@@ -140,7 +141,7 @@ async def dismiss_relationship_suggestion(
     agent_id: str,
     body: DismissSuggestionBody,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     agent, _ = await _get_agent_sql_sources(agent_id, db, user)
     dismissed = list(getattr(agent, "dismissed_relationship_suggestions", None) or [])
@@ -157,7 +158,7 @@ async def save_agent_relationships(
     agent_id: str,
     body: RelationshipSaveBody,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     agent, sources = await _get_agent_sql_sources(agent_id, db, user)
     source_rows = [_source_sql_payload(source) for source in sources]

--- a/backend/app/routers/stripe_router.py
+++ b/backend/app/routers/stripe_router.py
@@ -6,7 +6,8 @@ Stripe discovery and source metadata refresh.
 """
 import asyncio
 from fastapi import APIRouter, Depends, HTTPException
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.models import User, Source
 from app.database import get_db
 from sqlalchemy import select
@@ -17,7 +18,7 @@ router = APIRouter(prefix="/stripe", tags=["stripe"])
 
 
 @router.post("/test-connection")
-async def test_connection(body: dict, user: User = Depends(require_user)):
+async def test_connection(body: dict, scope: TenantScope = Depends(require_membership)):
     """Test Stripe API connection. Body: { "apiKey": "sk_..." }."""
     api_key = body.get("apiKey") or body.get("api_key") or ""
     if not api_key:
@@ -35,7 +36,7 @@ async def test_connection(body: dict, user: User = Depends(require_user)):
 
 
 @router.post("/discover")
-async def discover_resources(body: dict, user: User = Depends(require_user)):
+async def discover_resources(body: dict, scope: TenantScope = Depends(require_membership)):
     """Discover Stripe resources. Body: { "apiKey": "sk_...", "tables": ["customers", ...] }."""
     api_key = body.get("apiKey") or body.get("api_key") or ""
     if not api_key:
@@ -62,10 +63,10 @@ async def discover_resources(body: dict, user: User = Depends(require_user)):
 async def refresh_source_metadata(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Refresh Stripe source metadata (re-discover resources and update sample data)."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/routers/summary_router.py
+++ b/backend/app/routers/summary_router.py
@@ -10,7 +10,8 @@ from typing import Optional
 
 from app.database import get_db
 from app.models import User, Agent, Source, TableSummary, LlmSettings, LlmConfig
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.config import get_settings
 from app.scripts.summary_bigquery import generate_table_summary_bigquery
 from app.scripts.summary_csv import generate_table_summary_csv
@@ -58,25 +59,25 @@ class GenerateSummaryRequest(BaseModel):
 async def generate_summary(
     body: GenerateSummaryRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Generate a table summary (executive report) for the selected source. BigQuery only for now."""
-    r = await db.execute(select(Agent).where(Agent.id == body.agentId))
+    r = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
         raise HTTPException(404, "Agent not found")
 
     # Resolve source: by sourceId or active source for agent
     if body.sourceId:
-        r = await db.execute(select(Source).where(Source.id == body.sourceId, Source.user_id == user.id))
+        r = await db.execute(select(Source).where(Source.id == body.sourceId, tenant_filter(Source, scope)))
         source = r.scalar_one_or_none()
     else:
         r = await db.execute(
-            select(Source).where(Source.agent_id == body.agentId, Source.user_id == user.id, Source.is_active == True)
+            select(Source).where(Source.agent_id == body.agentId, tenant_filter(Source, scope), Source.is_active == True)
         )
         source = r.scalar_one_or_none()
         if not source:
-            r = await db.execute(select(Source).where(Source.agent_id == body.agentId, Source.user_id == user.id))
+            r = await db.execute(select(Source).where(Source.agent_id == body.agentId, tenant_filter(Source, scope)))
             source = r.scalar_one_or_none()
 
     if not source:
@@ -197,7 +198,7 @@ async def generate_summary(
 async def list_summaries(
     agent_id: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List table summaries, optionally filtered by workspace (agent_id)."""
     q = select(TableSummary).where(TableSummary.user_id == user.id).order_by(TableSummary.created_at.desc())
@@ -223,7 +224,7 @@ async def list_summaries(
 async def get_summary(
     summary_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Get a single table summary by id."""
     r = await db.execute(select(TableSummary).where(TableSummary.id == summary_id, TableSummary.user_id == user.id))
@@ -245,7 +246,7 @@ async def get_summary(
 async def delete_summary(
     summary_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Delete a table summary."""
     r = await db.execute(select(TableSummary).where(TableSummary.id == summary_id, TableSummary.user_id == user.id))

--- a/backend/app/routers/telegram_router.py
+++ b/backend/app/routers/telegram_router.py
@@ -111,9 +111,16 @@ async def create_bot_config(
     env_config = _env_bot_option()
     if env_config and env_config["bot_token"] == token:
         raise HTTPException(status_code=400, detail="This Telegram bot token is already configured as the default .env bot")
-    existing = await db.execute(select(TelegramBotConfig).where(TelegramBotConfig.bot_token == token))
-    if existing.scalar_one_or_none():
-        raise HTTPException(status_code=400, detail="This Telegram bot token is already registered")
+    # Deduplicate in-memory: bot_token is now encrypted at rest, so a
+    # WHERE on the ciphertext can't match a plaintext probe. Small table,
+    # one query + client-side compare is fine.
+    r_existing = await db.execute(select(TelegramBotConfig))
+    for _cfg in r_existing.scalars().all():
+        if (_cfg.bot_token or "") == token:
+            raise HTTPException(
+                status_code=400,
+                detail="This Telegram bot token is already registered",
+            )
 
     cfg = TelegramBotConfig(
         id=str(uuid.uuid4()),

--- a/backend/app/routers/template_router.py
+++ b/backend/app/routers/template_router.py
@@ -14,7 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.models import User, Source, Agent, Report, ReportTemplate, ReportTemplateRun, LlmConfig, LlmSettings
-from app.auth import require_user
+from app.auth import TenantScope, require_membership, require_user
+from app.services.tenant_scope import tenant_filter
 from app.config import get_settings
 from app.schemas import TemplateRunRequest
 from app.services import template_registry, template_executor
@@ -51,10 +52,10 @@ class GenerateTemplateRequest(BaseModel):
 async def list_templates(
     source_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List available report templates for a source (built-in + user-created)."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")
@@ -111,10 +112,10 @@ async def run_template(
     template_id: str,
     body: Optional[TemplateRunRequest] = None,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Execute all queries in a report template against the source."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")
@@ -167,7 +168,7 @@ async def list_template_runs(
     template_id: str,
     limit: int = 20,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List execution history for a template on a specific source."""
     q = (
@@ -199,17 +200,17 @@ async def generate_template(
     source_id: str,
     body: GenerateTemplateRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Use AI to generate a report template with SQL queries for a source."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")
 
     # Resolve LLM config
     llm_overrides = None
-    r_agent = await db.execute(select(Agent).where(Agent.id == body.agentId))
+    r_agent = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r_agent.scalar_one_or_none()
     if agent and agent.llm_config_id:
         r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id))
@@ -353,7 +354,7 @@ async def delete_template(
     source_id: str,
     template_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Delete a user-created template."""
     r = await db.execute(
@@ -449,7 +450,7 @@ async def run_template_as_report(
     template_id: str,
     body: RunReportRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Execute template queries and generate a styled HTML report with charts and LLM commentary."""
     import pandas as pd
@@ -459,7 +460,7 @@ async def run_template_as_report(
     import io
     import base64
 
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")
@@ -481,7 +482,7 @@ async def run_template_as_report(
 
     # Resolve LLM config
     llm_overrides = None
-    r_agent = await db.execute(select(Agent).where(Agent.id == body.agentId))
+    r_agent = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r_agent.scalar_one_or_none()
     if agent and agent.llm_config_id:
         r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id))
@@ -660,7 +661,7 @@ async def list_template_reports(
     source_id: str,
     template_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """List reports generated from a specific template."""
     r = await db.execute(
@@ -691,7 +692,7 @@ async def update_template_queries(
     template_id: str,
     body: UpdateQueriesRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Update the queries array of a user-created template."""
     r = await db.execute(
@@ -726,10 +727,10 @@ async def add_query_to_template(
     template_id: str,
     body: AddQueryRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Use AI to generate a new query and add it to the template."""
-    r_src = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r_src = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r_src.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")
@@ -747,7 +748,7 @@ async def add_query_to_template(
 
     # Resolve LLM
     llm_overrides = None
-    r_agent = await db.execute(select(Agent).where(Agent.id == body.agentId))
+    r_agent = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r_agent.scalar_one_or_none()
     if agent and agent.llm_config_id:
         r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id))
@@ -822,10 +823,10 @@ async def run_template_with_commentary(
     template_id: str,
     body: RunWithCommentaryRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Execute template queries then generate AI commentary per result."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")
@@ -845,7 +846,7 @@ async def run_template_with_commentary(
 
     # Resolve LLM
     llm_overrides = None
-    r_agent = await db.execute(select(Agent).where(Agent.id == body.agentId))
+    r_agent = await db.execute(select(Agent).where(Agent.id == body.agentId, tenant_filter(Agent, scope)))
     agent = r_agent.scalar_one_or_none()
     if agent and agent.llm_config_id:
         r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id))
@@ -894,11 +895,11 @@ async def customize_template(
     template_id: str,
     body: TemplateRunRequest,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Save user customizations for a built-in template (creates a user copy in DB)."""
     # Verify source ownership
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")
@@ -950,10 +951,10 @@ async def reset_template_customization(
     source_id: str,
     template_id: str,
     db: AsyncSession = Depends(get_db),
-    user: User = Depends(require_user),
+    scope: TenantScope = Depends(require_membership),
 ):
     """Reset user customizations for a template (delete the user copy)."""
-    r = await db.execute(select(Source).where(Source.id == source_id, Source.user_id == user.id))
+    r = await db.execute(select(Source).where(Source.id == source_id, tenant_filter(Source, scope)))
     source = r.scalar_one_or_none()
     if not source:
         raise HTTPException(404, "Source not found")

--- a/backend/app/services/alert_scheduler.py
+++ b/backend/app/services/alert_scheduler.py
@@ -208,9 +208,10 @@ async def _execute_single_alert(alert: Alert) -> None:
 
         duration_ms = int((time.monotonic() - start) * 1000)
 
-        # Save execution record
+        # Save execution record (inherits the parent alert's organization_id).
         execution = AlertExecution(
             id=exec_id,
+            organization_id=alert.organization_id,
             alert_id=alert.id,
             status=status,
             answer=answer[:10000] if answer else None,

--- a/backend/app/services/crypto.py
+++ b/backend/app/services/crypto.py
@@ -68,3 +68,206 @@ def decrypt_text(cipher: str) -> str:
         raise RuntimeError(
             "Failed to decrypt stored token. The encryption key has likely changed."
         ) from e
+
+
+# ---------------------------------------------------------------------------
+# Envelope encryption for JSON dicts and specific model fields
+#
+# Sources store credentials inside a free-form JSON `metadata_` column. Rather
+# than adding a dedicated encrypted column per source type, we wrap known
+# secret keys in an `{"__enc": "<fernet>"}` envelope. Reads transparently
+# unwrap. Anything not matching the envelope is returned as-is.
+#
+# Bot tokens (Telegram, WhatsApp, Slack) are scalar strings. The same Fernet
+# ciphertext format is applied with a magic-prefix sniff (`gAAAA`) so we can
+# tell encrypted from plaintext and avoid double-encryption on re-save.
+# ---------------------------------------------------------------------------
+
+# Known secret-carrying keys in Source.metadata_. Lowercase comparison.
+SOURCE_SECRET_KEYS: frozenset[str] = frozenset({
+    "password",
+    "connection_string",
+    "service_account_json",
+    "service_account_key",
+    "api_key",
+    "auth_token",
+    "bearer_token",
+    "access_token",
+    "secret_access_key",
+    "aws_secret_access_key",
+    "private_key",
+    "client_secret",
+})
+
+# Fernet ciphertext tokens start with "gAAAA" (version byte 0x80 + base64url).
+_FERNET_PREFIX = "gAAAA"
+
+
+def looks_encrypted(value: str) -> bool:
+    """Quick sniff: does this look like a Fernet token?"""
+    return isinstance(value, str) and value.startswith(_FERNET_PREFIX)
+
+
+def encrypt_scalar(value: str | None) -> str | None:
+    """Encrypt a scalar secret. No-op on None/empty/already-ciphertext."""
+    if value is None or value == "":
+        return value
+    if looks_encrypted(value):
+        return value
+    return encrypt_text(value)
+
+
+def decrypt_scalar(value: str | None) -> str | None:
+    """Return the plaintext for a scalar secret. No-op on None/empty.
+
+    If the value doesn't look like ciphertext we assume it is legacy
+    plaintext that hasn't been migrated yet and return it unchanged.
+    """
+    if value is None or value == "":
+        return value
+    if not looks_encrypted(value):
+        return value
+    return decrypt_text(value)
+
+
+def encrypt_secret_fields(obj: dict | None, secret_keys: frozenset[str] | set[str] | None = None) -> dict | None:
+    """Return a copy of `obj` with every value under a matching key wrapped
+    in `{"__enc": "<fernet>"}`. Nested dicts are recursed; lists are walked.
+
+    Already-wrapped envelopes and non-string values are left alone.
+    """
+    if obj is None:
+        return None
+    keys = secret_keys if secret_keys is not None else SOURCE_SECRET_KEYS
+
+    def _walk(node):
+        if isinstance(node, dict):
+            out: dict = {}
+            for k, v in node.items():
+                if isinstance(k, str) and k.lower() in keys:
+                    out[k] = _wrap(v)
+                else:
+                    out[k] = _walk(v)
+            return out
+        if isinstance(node, list):
+            return [_walk(v) for v in node]
+        return node
+
+    def _wrap(v):
+        if v is None or v == "":
+            return v
+        if isinstance(v, dict) and "__enc" in v:
+            return v  # already wrapped
+        if not isinstance(v, str):
+            # Don't try to encrypt non-strings (ints, bools). Upstream
+            # callers shouldn't put those under secret keys anyway.
+            return v
+        return {"__enc": encrypt_text(v)}
+
+    return _walk(obj)
+
+
+def decrypt_secret_fields(obj: dict | None) -> dict | None:
+    """Return a copy of `obj` with every `{"__enc": "<cipher>"}` envelope
+    replaced by the plaintext. Structure is otherwise preserved.
+    """
+    if obj is None:
+        return None
+
+    def _walk(node):
+        if isinstance(node, dict):
+            if "__enc" in node and len(node) == 1 and isinstance(node["__enc"], str):
+                return decrypt_text(node["__enc"])
+            return {k: _walk(v) for k, v in node.items()}
+        if isinstance(node, list):
+            return [_walk(v) for v in node]
+        return node
+
+    return _walk(obj)
+
+
+class EncryptedText:
+    """SQLAlchemy TypeDecorator for transparently-encrypted string columns.
+
+    Imported on demand by `app.models` — living here keeps crypto.py as
+    the single place that knows about Fernet.
+
+    Existing rows with plaintext values keep working: we detect ciphertext
+    via the `gAAAA` Fernet prefix and only decrypt then, so migrations can
+    ship this type before or after a data migration that re-encrypts
+    existing rows.
+    """
+
+    # Lazy-built once the module is first accessed, so test environments
+    # that override SECRET_KEY before importing models see the right key.
+    _built = None
+
+    def __new__(cls):  # pragma: no cover — factory
+        if cls._built is None:
+            from sqlalchemy.types import Text as _Text, TypeDecorator
+
+            class _EncryptedText(TypeDecorator):
+                impl = _Text
+                cache_ok = True
+
+                def process_bind_param(self, value, dialect):
+                    if value is None:
+                        return None
+                    if not isinstance(value, str):
+                        value = str(value)
+                    if looks_encrypted(value):
+                        return value
+                    return encrypt_text(value)
+
+                def process_result_value(self, value, dialect):
+                    if value is None or value == "":
+                        return value
+                    if not looks_encrypted(value):
+                        return value  # legacy plaintext from before migration
+                    try:
+                        return decrypt_text(value)
+                    except RuntimeError:
+                        return value  # surface rather than 500; operator will see and re-key
+
+            cls._built = _EncryptedText
+        return cls._built()
+
+
+def unlock_source_metadata(source) -> None:
+    """In-place decrypt of `source.metadata_` so downstream scripts see
+    plaintext values. Safe to call multiple times — decrypt is idempotent
+    on plaintext and envelope format."""
+    if source is None:
+        return
+    meta = getattr(source, "metadata_", None)
+    if not meta:
+        return
+    source.metadata_ = decrypt_secret_fields(meta)
+
+
+def mask_secret_fields(obj: dict | None, secret_keys: frozenset[str] | set[str] | None = None) -> dict | None:
+    """Return a copy of `obj` where every secret value is replaced by
+    `{"present": true}` (if set) or `None`. For use in list/get API
+    responses so we never echo a plaintext credential back to the client.
+    """
+    if obj is None:
+        return None
+    keys = secret_keys if secret_keys is not None else SOURCE_SECRET_KEYS
+
+    def _walk(node):
+        if isinstance(node, dict):
+            out: dict = {}
+            for k, v in node.items():
+                if isinstance(k, str) and k.lower() in keys:
+                    if v is None or v == "":
+                        out[k] = None
+                    else:
+                        out[k] = {"present": True}
+                else:
+                    out[k] = _walk(v)
+            return out
+        if isinstance(node, list):
+            return [_walk(v) for v in node]
+        return node
+
+    return _walk(obj)

--- a/backend/tests/test_tenancy.py
+++ b/backend/tests/test_tenancy.py
@@ -1,0 +1,367 @@
+"""Cross-tenant isolation and RBAC tests.
+
+Exercises the foundation introduced by the multi-tenant security PR:
+
+- A user in org A cannot load or mutate resources of org B, even if they
+  learned the UUIDs.
+- Role gates reject viewers from writes and non-admins from deletes.
+- Switching org via `/api/auth/switch-org` flips the tenant scope so the
+  same user sees a different set of resources.
+- Encryption: credentials land in the DB as `{"__enc": "..."}` envelopes
+  and `GET /api/sources` returns masked values.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.auth import create_access_token
+from app.models import (
+    Agent,
+    Organization,
+    OrganizationMembership,
+    Source,
+    User,
+)
+from app.services.crypto import SOURCE_SECRET_KEYS
+
+
+def _session_factory():
+    """Use the patched AsyncSessionLocal from `conftest` (the top-level
+    import binds to the pre-patch value)."""
+    import app.database as _db
+
+    return _db.AsyncSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+async def _make_user(db, email: str) -> User:
+    user = User(
+        id=str(uuid.uuid4()),
+        email=email,
+        hashed_password="x",  # placeholder; tests auth via JWT
+        role="user",
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_org(db, *, name: str, creator: User) -> Organization:
+    org = Organization(
+        id=str(uuid.uuid4()),
+        name=name,
+        slug=name.lower().replace(" ", "-") + "-" + uuid.uuid4().hex[:6],
+        created_by=creator.id,
+    )
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _add_member(db, *, user: User, org: Organization, role: str = "member") -> OrganizationMembership:
+    m = OrganizationMembership(
+        id=str(uuid.uuid4()),
+        user_id=user.id,
+        organization_id=org.id,
+        role=role,
+    )
+    db.add(m)
+    await db.flush()
+    return m
+
+
+def _token_for(user_id: str, org_id: str) -> str:
+    return create_access_token({"sub": user_id}, org_id=org_id)
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest_asyncio.fixture
+async def two_tenants(app):
+    """Build org_a owned by user_a and org_b owned by user_b plus one
+    shared user `user_both` who is `member` in both orgs.
+
+    Also seeds one Source and one Agent in each org so cross-org IDOR
+    attempts have something to aim at.
+    """
+    async with _session_factory()() as db:
+        user_a = await _make_user(db, "alice@example.com")
+        user_b = await _make_user(db, "bob@example.com")
+        user_both = await _make_user(db, "carol@example.com")
+
+        org_a = await _make_org(db, name="Acme", creator=user_a)
+        org_b = await _make_org(db, name="Beta", creator=user_b)
+
+        await _add_member(db, user=user_a, org=org_a, role="owner")
+        await _add_member(db, user=user_b, org=org_b, role="owner")
+        await _add_member(db, user=user_both, org=org_a, role="member")
+        await _add_member(db, user=user_both, org=org_b, role="viewer")
+
+        src_a = Source(
+            id=str(uuid.uuid4()),
+            user_id=user_a.id,
+            organization_id=org_a.id,
+            name="acme_sales",
+            type="bigquery",
+            metadata_={"project": "acme-prod"},
+        )
+        src_b = Source(
+            id=str(uuid.uuid4()),
+            user_id=user_b.id,
+            organization_id=org_b.id,
+            name="beta_events",
+            type="bigquery",
+            metadata_={"project": "beta-prod"},
+        )
+        agent_a = Agent(
+            id=str(uuid.uuid4()),
+            user_id=user_a.id,
+            organization_id=org_a.id,
+            name="Acme analysis",
+            workspace_type="analysis",
+            source_ids=[src_a.id],
+            source_relationships=[],
+            suggested_questions=[],
+        )
+        agent_b = Agent(
+            id=str(uuid.uuid4()),
+            user_id=user_b.id,
+            organization_id=org_b.id,
+            name="Beta analysis",
+            workspace_type="analysis",
+            source_ids=[src_b.id],
+            source_relationships=[],
+            suggested_questions=[],
+        )
+        db.add_all([src_a, src_b, agent_a, agent_b])
+        await db.commit()
+
+        yield {
+            "user_a": user_a,
+            "user_b": user_b,
+            "user_both": user_both,
+            "org_a": org_a,
+            "org_b": org_b,
+            "src_a": src_a,
+            "src_b": src_b,
+            "agent_a": agent_a,
+            "agent_b": agent_b,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant IDOR checks
+# ---------------------------------------------------------------------------
+
+
+async def test_user_a_cannot_load_org_b_source(client, two_tenants):
+    """IDOR: user A knows the UUID of org B's source — must still 404."""
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+
+    r = await client.get(f"/api/sources", headers=_headers(token))
+    assert r.status_code == 200
+    ids_in_list = {s["id"] for s in r.json()}
+    assert t["src_a"].id in ids_in_list
+    assert t["src_b"].id not in ids_in_list
+
+
+async def test_user_a_cannot_load_org_b_agent(client, two_tenants):
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+
+    # List must not include the other org's agent
+    r = await client.get("/api/agents", headers=_headers(token))
+    assert r.status_code == 200
+    ids_in_list = {a["id"] for a in r.json()}
+    assert t["agent_b"].id not in ids_in_list
+
+    # Direct fetch by UUID must 404
+    r = await client.get(f"/api/agents/{t['agent_b'].id}", headers=_headers(token))
+    assert r.status_code == 404
+
+
+async def test_user_a_cannot_patch_org_b_source(client, two_tenants):
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+    r = await client.patch(
+        f"/api/sources/{t['src_b'].id}",
+        json={"is_active": False},
+        headers=_headers(token),
+    )
+    assert r.status_code == 404
+
+
+async def test_user_a_cannot_delete_org_b_source(client, two_tenants):
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+    r = await client.delete(
+        f"/api/sources/{t['src_b'].id}", headers=_headers(token)
+    )
+    # owner of own org → role check passes, then 404 because org mismatch
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Role gates
+# ---------------------------------------------------------------------------
+
+
+async def test_viewer_cannot_create_source(client, two_tenants):
+    """user_both is viewer in org_b — POST /api/sources must 403."""
+    t = two_tenants
+    token = _token_for(t["user_both"].id, t["org_b"].id)
+    r = await client.post(
+        "/api/sources",
+        json={"name": "x", "type": "sql_database", "metadata": {}},
+        headers=_headers(token),
+    )
+    assert r.status_code == 403
+
+
+async def test_member_can_create_source(client, two_tenants):
+    """user_both is member in org_a — POST /api/sources must 200."""
+    t = two_tenants
+    token = _token_for(t["user_both"].id, t["org_a"].id)
+    r = await client.post(
+        "/api/sources",
+        json={"name": "member-created", "type": "sql_database", "metadata": {}},
+        headers=_headers(token),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["name"] == "member-created"
+
+
+async def test_member_cannot_delete_source(client, two_tenants):
+    """user_both is member (not admin) in org_a — DELETE must 403."""
+    t = two_tenants
+    token = _token_for(t["user_both"].id, t["org_a"].id)
+    r = await client.delete(
+        f"/api/sources/{t['src_a'].id}", headers=_headers(token)
+    )
+    assert r.status_code == 403
+
+
+async def test_owner_can_delete_source(client, two_tenants):
+    """user_a is owner in org_a — DELETE works."""
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+    r = await client.delete(
+        f"/api/sources/{t['src_a'].id}", headers=_headers(token)
+    )
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Org switching
+# ---------------------------------------------------------------------------
+
+
+async def test_switch_org_flips_visible_resources(client, two_tenants):
+    """user_both lists agents under org_a then switches to org_b and sees the
+    other set without re-login."""
+    t = two_tenants
+    token_a = _token_for(t["user_both"].id, t["org_a"].id)
+    r = await client.get("/api/agents", headers=_headers(token_a))
+    assert r.status_code == 200
+    ids_a = {a["id"] for a in r.json()}
+    assert t["agent_a"].id in ids_a
+    assert t["agent_b"].id not in ids_a
+
+    # Switch to org_b
+    r = await client.post(
+        "/api/auth/switch-org",
+        json={"organization_id": t["org_b"].id},
+        headers=_headers(token_a),
+    )
+    assert r.status_code == 200, r.text
+    token_b = r.json()["access_token"]
+
+    r = await client.get("/api/agents", headers=_headers(token_b))
+    assert r.status_code == 200
+    ids_b = {a["id"] for a in r.json()}
+    assert t["agent_b"].id in ids_b
+    assert t["agent_a"].id not in ids_b
+
+
+async def test_switch_to_org_without_membership_is_403(client, two_tenants):
+    """user_a is not a member of org_b — switch must 403."""
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+    r = await client.post(
+        "/api/auth/switch-org",
+        json={"organization_id": t["org_b"].id},
+        headers=_headers(token),
+    )
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Secret encryption
+# ---------------------------------------------------------------------------
+
+
+async def test_create_source_encrypts_secret_fields_at_rest(client, two_tenants):
+    """POST /api/sources with a password → DB row stores `{"__enc": "..."}`,
+    API response masks the secret, `scope.organization_id` is set."""
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+    r = await client.post(
+        "/api/sources",
+        json={
+            "name": "secrets-check",
+            "type": "sql_database",
+            "metadata": {
+                "host": "db.example.com",
+                "password": "hunter2",
+                "api_key": "sk-xyz",
+            },
+        },
+        headers=_headers(token),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["metaJSON"]["host"] == "db.example.com"
+    # Response is masked, not plaintext
+    assert body["metaJSON"]["password"] == {"present": True}
+    assert body["metaJSON"]["api_key"] == {"present": True}
+
+    # DB row has the envelope — plaintext never stored
+    async with _session_factory()() as db:
+        r_db = await db.execute(
+            select(Source).where(Source.id == body["id"])
+        )
+        src = r_db.scalar_one()
+        meta = src.metadata_ or {}
+        assert meta.get("host") == "db.example.com"
+        assert isinstance(meta.get("password"), dict) and "__enc" in meta["password"]
+        assert isinstance(meta.get("api_key"), dict) and "__enc" in meta["api_key"]
+
+
+def test_known_source_secret_keys_include_critical_ones():
+    """Snapshot test so we don't silently remove coverage for a secret key."""
+    must_cover = {
+        "password",
+        "api_key",
+        "service_account_json",
+        "connection_string",
+        "secret_access_key",
+        "private_key",
+    }
+    missing = must_cover - SOURCE_SECRET_KEYS
+    assert not missing, f"SOURCE_SECRET_KEYS lost coverage for: {missing}"

--- a/backend/tests/test_tenancy.py
+++ b/backend/tests/test_tenancy.py
@@ -365,3 +365,104 @@ def test_known_source_secret_keys_include_critical_ones():
     }
     missing = must_cover - SOURCE_SECRET_KEYS
     assert not missing, f"SOURCE_SECRET_KEYS lost coverage for: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Organization member management
+# ---------------------------------------------------------------------------
+
+
+async def test_owner_can_list_and_add_members(client, two_tenants):
+    """user_a is owner of org_a. They can list members and add user_both as admin."""
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+
+    r = await client.get(f"/api/organizations/{t['org_a'].id}/members", headers=_headers(token))
+    assert r.status_code == 200
+    members = r.json()
+    # Seeded with user_a (owner) + user_both (member).
+    emails = {m["email"] for m in members}
+    assert t["user_a"].email in emails
+    assert t["user_both"].email in emails
+
+
+async def test_admin_cannot_grant_owner(client, two_tenants):
+    """member user_both gets promoted to admin in org_a; then tries to
+    promote someone to owner — must 403."""
+    t = two_tenants
+    owner_token = _token_for(t["user_a"].id, t["org_a"].id)
+    # First owner promotes user_both to admin
+    r = await client.patch(
+        f"/api/organizations/{t['org_a'].id}/members/{t['user_both'].id}",
+        json={"role": "admin"},
+        headers=_headers(owner_token),
+    )
+    assert r.status_code == 200
+
+    # Now admin user_both tries to grant owner — rejected
+    admin_token = _token_for(t["user_both"].id, t["org_a"].id)
+    r = await client.post(
+        f"/api/organizations/{t['org_a'].id}/members",
+        json={"email": t["user_b"].email, "role": "owner"},
+        headers=_headers(admin_token),
+    )
+    assert r.status_code == 403
+
+
+async def test_last_owner_cannot_be_demoted(client, two_tenants):
+    """org_a has exactly one owner (user_a). Trying to demote them should 400."""
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+    r = await client.patch(
+        f"/api/organizations/{t['org_a'].id}/members/{t['user_a'].id}",
+        json={"role": "admin"},
+        headers=_headers(token),
+    )
+    assert r.status_code == 400
+
+
+async def test_viewer_cannot_manage_members(client, two_tenants):
+    """user_both is viewer in org_b — GET members must 403."""
+    t = two_tenants
+    token = _token_for(t["user_both"].id, t["org_b"].id)
+    r = await client.get(
+        f"/api/organizations/{t['org_b'].id}/members", headers=_headers(token)
+    )
+    assert r.status_code == 403
+
+
+async def test_cannot_manage_members_of_other_org(client, two_tenants):
+    """user_a is owner in org_a. Tries to manage org_b — must 403 even though
+    their role is 'owner' (of the wrong org)."""
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+    r = await client.get(
+        f"/api/organizations/{t['org_b'].id}/members", headers=_headers(token)
+    )
+    # Caller's scope is org_a, path is org_b — _ensure_caller_can_manage blocks with 403.
+    assert r.status_code == 403
+
+
+async def test_create_org_makes_caller_owner(client, two_tenants):
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+    r = await client.post(
+        "/api/organizations",
+        json={"name": "New Org"},
+        headers=_headers(token),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["name"] == "New Org"
+    assert body["role"] == "owner"
+
+
+async def test_add_member_requires_registered_user(client, two_tenants):
+    t = two_tenants
+    token = _token_for(t["user_a"].id, t["org_a"].id)
+    r = await client.post(
+        f"/api/organizations/{t['org_a'].id}/members",
+        json={"email": "nobody-not-registered@example.com", "role": "member"},
+        headers=_headers(token),
+    )
+    assert r.status_code == 404

--- a/backend/tests/test_tenancy_lint.py
+++ b/backend/tests/test_tenancy_lint.py
@@ -1,0 +1,244 @@
+"""Static lint: every query against a tenant-scoped model must include
+either `tenant_filter(Model, …)` or an explicit `Model.organization_id ==`
+predicate in its `WHERE` clause.
+
+Runs as a normal pytest so it ships in CI. It is AST-based, not regex —
+so `select(Source).where(foo == 1)` triggers a failure, while
+`select(Source).where(tenant_filter(Source, scope), Source.id == sid)`
+passes.
+
+The rule is **additive**: user_id filters are still allowed (and often
+present) but a tenant filter is now mandatory.
+
+A per-file allowlist (`ALLOW_FILES`) exempts modules that legitimately
+need to query across tenants (the auth_router resolving the active org,
+the multi-tenant test suite itself, the migration scripts, etc.).
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+from typing import Iterable
+
+import pytest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+APP_DIR = ROOT / "app"
+
+# SQLAlchemy models that carry `organization_id` and therefore must be
+# filtered by the caller's tenant on every read/write.
+TENANT_SCOPED_MODELS: frozenset[str] = frozenset({
+    "Source",
+    "Agent",
+    "PipelineRun",
+    "PipelineVersion",
+    "LineageEdge",
+    "ApiKey",
+    "GithubConnection",
+    "QASession",
+    "Dashboard",
+    "DashboardChart",
+    "Alert",
+    "AlertExecution",
+})
+
+# Files allowed to query those models without a tenant filter. Each entry
+# MUST include a `why` comment so future contributors know whether to add
+# a new exception or fix the code. Paths are relative to the backend/ root.
+ALLOW_FILES: dict[str, str] = {
+    # The tenancy test suite deliberately probes cross-org access.
+    "tests/test_tenancy.py": "test fixtures deliberately seed cross-tenant data",
+    "tests/test_pipeline_versioning.py": "test seeds single-tenant data directly",
+    "tests/test_lineage.py": "tracker unit tests operate on scope-less sessions",
+    "tests/test_storage.py": "storage tests don't touch models",
+    "tests/test_tenancy_lint.py": "this file",
+    # auth_router needs to look up memberships and user's orgs globally
+    # before the tenant scope has been established.
+    "app/routers/auth_router.py": "resolves the active org on login/switch-org",
+    # The MCP scope resolver looks up an ApiKey by hash before knowing the
+    # tenant; the key itself identifies the tenant.
+    "app/mcp_server.py": "resolves the caller's tenant from the API key",
+    # Core auth dependency: looks up ApiKey / memberships before scope exists.
+    "app/auth.py": "core scope resolver — by definition runs before tenant is known",
+    # Lineage service filters by run_id which is already tenant-scoped
+    # through the PipelineRun row.
+    "app/services/lineage.py": "edges inherit tenant via their parent run",
+    # Audit router filters by organization_id but on a generic model that
+    # doesn't live in the scoped list — skip for now.
+    "app/routers/audit_router.py": "audit log tenant filter applied separately",
+    # Public API gets its scope from the API key; filter is applied via
+    # key.organization_id but not through a Model.organization_id predicate.
+    "app/routers/public_api_router.py": "scope resolved via ApiKey",
+    # Pipeline versioning service: callers pass an already-scoped agent_id
+    # (validated by _require_agent in the router). The queries narrow by
+    # agent_id + pipeline_id, which transitively enforces the tenant.
+    "app/services/pipeline_versioning.py": "agent_id is pre-validated to belong to the caller's org",
+    # Alert scheduler: background worker that scans ALL alerts to fire
+    # them on schedule. Cross-tenant by design; no caller context.
+    "app/services/alert_scheduler.py": "background scheduler scans all tenants' alerts by design",
+}
+
+
+def _iter_python_files() -> Iterable[pathlib.Path]:
+    for path in APP_DIR.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def _rel(path: pathlib.Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+class _SelectVisitor(ast.NodeVisitor):
+    """Finds each `select(<Model>)` call-chain and checks that the chain
+    applies either `tenant_filter(<Model>, ...)` or `<Model>.organization_id == ...`
+    somewhere inside its `.where(...)`, `.filter(...)`, or `.where_and(...)`
+    invocations."""
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        self.violations: list[tuple[int, str, str]] = []  # (lineno, model, snippet)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Flatten attribute chains so we can walk `.where().where().filter()`.
+        chain = _chain_of_calls(node)
+        if not chain:
+            self.generic_visit(node)
+            return
+
+        root_call = chain[0]
+        if not _is_select_call(root_call):
+            self.generic_visit(node)
+            return
+
+        tenant_models = [m for m in _models_in_select(root_call) if m in TENANT_SCOPED_MODELS]
+        if not tenant_models:
+            self.generic_visit(node)
+            return
+
+        # Collect all filter expressions across the chain.
+        filter_exprs: list[ast.expr] = []
+        for call in chain[1:]:
+            if isinstance(call.func, ast.Attribute) and call.func.attr in (
+                "where",
+                "filter",
+                "filter_by",
+            ):
+                filter_exprs.extend(call.args)
+
+        for model in tenant_models:
+            if not _filters_have_tenant_check(filter_exprs, model):
+                self.violations.append(
+                    (node.lineno, model, ast.unparse(node)[:140]),
+                )
+
+        # Don't recurse into this chain again — its inner calls were already
+        # considered as part of the chain walk above.
+
+
+def _chain_of_calls(node: ast.Call) -> list[ast.Call]:
+    """Walk back through `.where(...).where(...).filter(...)` and return
+    [root_select_call, where1, where2, ...]. Returns [] when the outermost
+    call is not itself a chain of attributes."""
+    chain: list[ast.Call] = [node]
+    current = node.func
+    while isinstance(current, ast.Attribute):
+        parent = current.value
+        if isinstance(parent, ast.Call):
+            chain.append(parent)
+            current = parent.func
+        else:
+            break
+    chain.reverse()
+    return chain
+
+
+def _is_select_call(call: ast.Call) -> bool:
+    func = call.func
+    if isinstance(func, ast.Name) and func.id == "select":
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == "select":
+        return True
+    return False
+
+
+def _models_in_select(call: ast.Call) -> list[str]:
+    out: list[str] = []
+    for arg in call.args:
+        if isinstance(arg, ast.Name):
+            out.append(arg.id)
+        elif isinstance(arg, ast.Attribute) and isinstance(arg.value, ast.Name):
+            # e.g. select(Source.id) — first Name walk yields the model
+            out.append(arg.value.id)
+    return out
+
+
+def _filters_have_tenant_check(exprs: list[ast.expr], model: str) -> bool:
+    for e in exprs:
+        if _contains_tenant_check(e, model):
+            return True
+    return False
+
+
+def _contains_tenant_check(node: ast.AST, model: str) -> bool:
+    for child in ast.walk(node):
+        if (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Name)
+            and child.func.id == "tenant_filter"
+            and child.args
+            and isinstance(child.args[0], ast.Name)
+            and child.args[0].id == model
+        ):
+            return True
+        if (
+            isinstance(child, ast.Compare)
+            and isinstance(child.left, ast.Attribute)
+            and isinstance(child.left.value, ast.Name)
+            and child.left.value.id == model
+            and child.left.attr == "organization_id"
+        ):
+            return True
+    return False
+
+
+def test_no_tenant_scoped_query_misses_organization_filter():
+    violations: list[str] = []
+    for path in _iter_python_files():
+        rel = _rel(path)
+        if rel in ALLOW_FILES:
+            continue
+        try:
+            tree = ast.parse(path.read_text(), filename=rel)
+        except SyntaxError:
+            continue  # not our problem here
+        visitor = _SelectVisitor(rel)
+        visitor.visit(tree)
+        for lineno, model, snippet in visitor.violations:
+            violations.append(f"{rel}:{lineno} select({model}) without tenant filter — {snippet}")
+
+    if violations:
+        formatted = "\n".join(f"  - {v}" for v in violations)
+        allow_hint = (
+            "\n\nIf this query genuinely needs to span tenants, add the file "
+            "path to ALLOW_FILES in tests/test_tenancy_lint.py with a short "
+            "`why` comment. Otherwise apply `tenant_filter(<Model>, scope)` "
+            "or a `<Model>.organization_id == ...` predicate."
+        )
+        pytest.fail(
+            f"Found {len(violations)} tenant-scoped query without organization filter:\n{formatted}{allow_hint}"
+        )
+
+
+def test_allowlist_stays_minimal():
+    """Snapshot test so we notice when someone adds new exceptions. Keep
+    ALLOW_FILES small — every entry is a place where a bug could hide
+    behind 'trust me, this one's fine'."""
+    # Bump this ceiling intentionally in the same commit that adds a new
+    # entry to ALLOW_FILES so reviewers catch the expansion.
+    assert len(ALLOW_FILES) <= 14, (
+        f"ALLOW_FILES has grown to {len(ALLOW_FILES)} entries. "
+        "Review the list; each bypasses the multi-tenant lint."
+    )

--- a/src/components/OrganizationPanel.tsx
+++ b/src/components/OrganizationPanel.tsx
@@ -1,0 +1,291 @@
+import { Loader2, Trash2, UserPlus } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/hooks/useAuth";
+import { api } from "@/services/apiClient";
+
+
+interface Member {
+  user_id: string;
+  email: string;
+  role: "owner" | "admin" | "member" | "viewer";
+  joined_at: string | null;
+}
+
+
+const ROLE_OPTIONS: Array<{ value: Member["role"]; label: string }> = [
+  { value: "viewer", label: "Viewer (read only)" },
+  { value: "member", label: "Member (create/edit)" },
+  { value: "admin", label: "Admin (delete, manage members)" },
+  { value: "owner", label: "Owner (full control)" },
+];
+
+
+/**
+ * Organization settings panel rendered inside the Account page.
+ *
+ * Visibility: any member sees the org info; only admins/owners can manage
+ * members. The backend enforces the same rules — this is UX polish so we
+ * don't render disabled controls that will 403 anyway.
+ */
+export default function OrganizationPanel() {
+  const { activeOrganizationId, organizations, activeRole } = useAuth();
+  const { toast } = useToast();
+
+  const [members, setMembers] = useState<Member[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [newEmail, setNewEmail] = useState("");
+  const [newRole, setNewRole] = useState<Member["role"]>("member");
+
+  const activeOrg = useMemo(
+    () => organizations.find((o) => o.id === activeOrganizationId) ?? null,
+    [organizations, activeOrganizationId],
+  );
+
+  const canManage = activeRole === "owner" || activeRole === "admin";
+  const isOwner = activeRole === "owner";
+
+  const reload = useCallback(async () => {
+    if (!activeOrganizationId) return;
+    setLoading(true);
+    try {
+      const data = await api<Member[]>(`/api/organizations/${activeOrganizationId}/members`);
+      setMembers(data);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Failed to load members";
+      toast({ title: "Error", description: msg, variant: "destructive" });
+      setMembers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [activeOrganizationId, toast]);
+
+  useEffect(() => {
+    if (canManage) {
+      void reload();
+    } else {
+      setLoading(false);
+    }
+  }, [canManage, reload]);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newEmail.trim() || !activeOrganizationId) return;
+    setAdding(true);
+    try {
+      await api(`/api/organizations/${activeOrganizationId}/members`, {
+        method: "POST",
+        body: JSON.stringify({ email: newEmail.trim(), role: newRole }),
+      });
+      toast({ title: "Member added", description: newEmail });
+      setNewEmail("");
+      setNewRole("member");
+      await reload();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Failed to add member";
+      toast({ title: "Failed to add member", description: msg, variant: "destructive" });
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleChangeRole = async (userId: string, role: Member["role"]) => {
+    if (!activeOrganizationId) return;
+    try {
+      await api(`/api/organizations/${activeOrganizationId}/members/${userId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ role }),
+      });
+      await reload();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Failed to update role";
+      toast({ title: "Failed to update role", description: msg, variant: "destructive" });
+    }
+  };
+
+  const handleRemove = async (userId: string, email: string) => {
+    if (!activeOrganizationId) return;
+    if (!window.confirm(`Remove ${email} from the organization?`)) return;
+    try {
+      await api(`/api/organizations/${activeOrganizationId}/members/${userId}`, {
+        method: "DELETE",
+      });
+      toast({ title: "Member removed", description: email });
+      await reload();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Failed to remove member";
+      toast({ title: "Failed to remove member", description: msg, variant: "destructive" });
+    }
+  };
+
+  if (!activeOrg) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-sm text-muted-foreground">
+          No active organization. Use the switcher in the top bar to pick one.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Organization</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-1 text-sm">
+          <div className="text-lg font-medium">{activeOrg.name}</div>
+          <div className="text-muted-foreground">
+            Slug: <code>{activeOrg.slug ?? "—"}</code>
+          </div>
+          <div className="text-muted-foreground">Your role: {activeRole ?? activeOrg.role}</div>
+        </CardContent>
+      </Card>
+
+      {!canManage ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Members</CardTitle>
+          </CardHeader>
+          <CardContent className="py-4 text-sm text-muted-foreground">
+            You need the admin or owner role to view and manage members.
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <UserPlus className="h-4 w-4" />
+                Add member
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleAdd} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                <div className="flex-1">
+                  <Label htmlFor="org-new-email">User email</Label>
+                  <Input
+                    id="org-new-email"
+                    type="email"
+                    placeholder="user@example.com"
+                    value={newEmail}
+                    onChange={(e) => setNewEmail(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="w-full sm:w-56">
+                  <Label htmlFor="org-new-role">Role</Label>
+                  <Select
+                    value={newRole}
+                    onValueChange={(v) => setNewRole(v as Member["role"])}
+                  >
+                    <SelectTrigger id="org-new-role">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ROLE_OPTIONS.filter((r) => r.value !== "owner" || isOwner).map((r) => (
+                        <SelectItem key={r.value} value={r.value}>
+                          {r.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button type="submit" disabled={adding}>
+                  {adding ? <Loader2 className="h-4 w-4 animate-spin" /> : "Add"}
+                </Button>
+              </form>
+              <p className="mt-3 text-xs text-muted-foreground">
+                The user must already have a Data Talks account. Self-serve invites are not yet
+                supported.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Members ({members?.length ?? 0})</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {loading ? (
+                <div className="py-8 text-center text-sm text-muted-foreground">
+                  <Loader2 className="mx-auto h-4 w-4 animate-spin" />
+                </div>
+              ) : members && members.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead className="text-left text-xs uppercase text-muted-foreground">
+                      <tr>
+                        <th className="py-2">Email</th>
+                        <th className="py-2">Role</th>
+                        <th className="py-2">Joined</th>
+                        <th className="py-2 text-right">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {members.map((m) => (
+                        <tr key={m.user_id} className="border-t">
+                          <td className="py-2">{m.email}</td>
+                          <td className="py-2">
+                            <Select
+                              value={m.role}
+                              onValueChange={(v) => handleChangeRole(m.user_id, v as Member["role"])}
+                              disabled={!isOwner && m.role === "owner"}
+                            >
+                              <SelectTrigger className="h-8 w-32">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {ROLE_OPTIONS.filter((r) => r.value !== "owner" || isOwner).map((r) => (
+                                  <SelectItem key={r.value} value={r.value}>
+                                    {r.label.split(" (")[0]}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </td>
+                          <td className="py-2 text-xs text-muted-foreground">
+                            {m.joined_at
+                              ? new Date(m.joined_at).toLocaleDateString()
+                              : "—"}
+                          </td>
+                          <td className="py-2 text-right">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => handleRemove(m.user_id, m.email)}
+                              disabled={!isOwner && m.role === "owner"}
+                              aria-label={`Remove ${m.email}`}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div className="py-4 text-sm text-muted-foreground">No members yet.</div>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuLabel,
 } from "@/components/ui/dropdown-menu";
 import LanguageSelector from "@/components/ui/language-selector";
+import OrgSwitcher from "@/components/layout/OrgSwitcher";
 
 const NavBar = () => {
   const { user, logout, loginRequired } = useAuth();
@@ -37,6 +38,7 @@ const NavBar = () => {
             <BookOpen className="h-4 w-4" />
             <span className="hidden sm:inline">{t('nav.documentation')}</span>
           </Link>
+          <OrgSwitcher />
           <LanguageSelector />
           {user ? (
             <DropdownMenu>

--- a/src/components/layout/OrgSwitcher.tsx
+++ b/src/components/layout/OrgSwitcher.tsx
@@ -1,0 +1,100 @@
+import { Building2, Check, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { useAuth } from "@/hooks/useAuth";
+import { cn } from "@/lib/utils";
+
+
+/**
+ * Compact organization picker rendered in the top navigation bar.
+ *
+ * Hidden when the caller has only one org — there's nothing to switch to and
+ * the dropdown just adds noise. Also hidden in guest mode so the "Guest
+ * workspace" pseudo-org doesn't appear as a standalone UI element.
+ */
+export default function OrgSwitcher() {
+  const { organizations, activeOrganizationId, switchOrganization, initializing, loginRequired } = useAuth();
+  const { t } = useLanguage();
+  const [switching, setSwitching] = useState(false);
+
+  if (initializing) return null;
+  if (!loginRequired && organizations.length <= 1) return null;
+  if (organizations.length === 0) return null;
+
+  const active = organizations.find((o) => o.id === activeOrganizationId) || organizations[0];
+
+  const handleSwitch = async (orgId: string) => {
+    if (orgId === activeOrganizationId || switching) return;
+    setSwitching(true);
+    try {
+      await switchOrganization(orgId);
+      // `switchOrganization` reloads the page on success, so we only land
+      // here on failure.
+    } catch (e) {
+      console.error("Failed to switch organization:", e);
+      setSwitching(false);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="gap-2 max-w-[200px]"
+          data-walkthrough="org-switcher"
+          disabled={switching}
+        >
+          {switching ? (
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+          ) : (
+            <Building2 className="h-4 w-4 shrink-0" />
+          )}
+          <span className="truncate font-medium">{active.name}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+          {t("org.switcher.label") ?? "Organization"}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {organizations.map((org) => {
+          const isActive = org.id === activeOrganizationId;
+          return (
+            <DropdownMenuItem
+              key={org.id}
+              onClick={() => handleSwitch(org.id)}
+              className="cursor-pointer"
+            >
+              <div className="flex w-full items-center justify-between gap-2">
+                <div className="min-w-0">
+                  <div className={cn("truncate", isActive && "font-medium")}>{org.name}</div>
+                  <div className="truncate text-xs text-muted-foreground">{org.role}</div>
+                </div>
+                {isActive && <Check className="h-4 w-4 shrink-0 text-primary" />}
+              </div>
+            </DropdownMenuItem>
+          );
+        })}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link to="/account?tab=organization" className="cursor-pointer text-sm">
+            {t("org.switcher.manage") ?? "Manage organization"}
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/layout/OrgSwitcher.tsx
+++ b/src/components/layout/OrgSwitcher.tsx
@@ -90,7 +90,7 @@ export default function OrgSwitcher() {
         })}
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
-          <Link to="/account?tab=organization" className="cursor-pointer text-sm">
+          <Link to="/account?section=organization" className="cursor-pointer text-sm">
             {t("org.switcher.manage") ?? "Manage organization"}
           </Link>
         </DropdownMenuItem>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -6,6 +6,19 @@ export interface User {
   email: string;
   name: string;
   role?: string;
+  /** The caller's role in the active organization (viewer|member|admin|owner).
+   *  Distinct from `role`, which is the legacy admin/user superuser flag. */
+  activeRole?: string;
+  /** The caller's currently-active organization id, driven by the JWT
+   *  `org_id` claim. Switching orgs reissues the JWT. */
+  activeOrganizationId?: string;
+}
+
+export interface Organization {
+  id: string;
+  name: string;
+  slug?: string;
+  role: string;
 }
 
 export interface AuthSession {
@@ -30,18 +43,53 @@ const cleanupAuthState = () => {
   } catch { /* intentional */ }
 };
 
-const toUserFromApi = (u: { id: string; email?: string; role?: string }) => ({
+const toUserFromApi = (
+  u: { id: string; email?: string; role?: string; organization_id?: string },
+  extra: { activeRole?: string; activeOrganizationId?: string } = {},
+): User => ({
   id: u.id,
   email: (u as { email?: string }).email ?? "",
   name: ((u as { email?: string }).email ?? "").split("@")[0] || "User",
   role: (u as { role?: string }).role ?? "user",
+  activeRole: extra.activeRole,
+  activeOrganizationId:
+    extra.activeOrganizationId ?? (u as { organization_id?: string }).organization_id,
 });
+
+/** The backend `/api/auth/me` response changed shape with multi-tenancy. New
+ *  shape: `{ user, organizations, active_organization_id, active_role }`.
+ *  Old shape: `{ id, email, role, organization_id }`. Handle both so a
+ *  partial rollout doesn't break. */
+const parseMe = (
+  data: Record<string, unknown>,
+): { user: User; orgs: Organization[]; activeOrgId: string | undefined } => {
+  if (data && typeof data === "object" && "user" in data && "organizations" in data) {
+    const userPayload = data.user as {
+      id: string;
+      email?: string;
+      role?: string;
+      organization_id?: string;
+    };
+    const orgs = (data.organizations as Organization[]) || [];
+    const activeOrgId = (data.active_organization_id as string | undefined) ?? undefined;
+    const activeRole = (data.active_role as string | undefined) ?? undefined;
+    return {
+      user: toUserFromApi(userPayload, { activeOrganizationId: activeOrgId, activeRole }),
+      orgs,
+      activeOrgId,
+    };
+  }
+  // Legacy flat shape.
+  return { user: toUserFromApi(data as { id: string; email?: string; role?: string }), orgs: [], activeOrgId: undefined };
+};
 
 export function useAuth() {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<AuthSession | null>(null);
   const [initializing, setInitializing] = useState(true);
   const [loginRequired, setLoginRequired] = useState(false);
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [activeOrganizationId, setActiveOrganizationId] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     const base = getApiUrl();
@@ -68,9 +116,11 @@ export function useAuth() {
             .then((data) => {
               if (cancelled) return;
               if (data) {
-                const u = toUserFromApi(data);
+                const { user: u, orgs, activeOrgId } = parseMe(data);
                 setUser(u);
                 setSession({ user: u });
+                setOrganizations(orgs);
+                setActiveOrganizationId(activeOrgId);
               } else {
                 setToken(null);
                 setUser(null);
@@ -84,9 +134,11 @@ export function useAuth() {
             .then((data) => {
               if (cancelled) return;
               if (data) {
-                const u = toUserFromApi(data);
+                const { user: u, orgs, activeOrgId } = parseMe(data);
                 setUser(u);
                 setSession({ user: u });
+                setOrganizations(orgs);
+                setActiveOrganizationId(activeOrgId);
               }
             });
         }
@@ -126,9 +178,13 @@ export function useAuth() {
     }
     const data = await res.json();
     setToken(data.access_token);
-    const u = toUserFromApi(data.user);
+    const u = toUserFromApi(data.user, {
+      activeOrganizationId: data.active_organization_id,
+    });
     setUser(u);
     setSession({ user: u });
+    if (Array.isArray(data.organizations)) setOrganizations(data.organizations);
+    if (data.active_organization_id) setActiveOrganizationId(data.active_organization_id);
     return u;
   }, []);
 
@@ -145,9 +201,13 @@ export function useAuth() {
     }
     const data = await res.json();
     setToken(data.access_token);
-    const u = toUserFromApi(data.user);
+    const u = toUserFromApi(data.user, {
+      activeOrganizationId: data.active_organization_id,
+    });
     setUser(u);
     setSession({ user: u });
+    if (Array.isArray(data.organizations)) setOrganizations(data.organizations);
+    if (data.active_organization_id) setActiveOrganizationId(data.active_organization_id);
     return u;
   }, []);
 
@@ -164,10 +224,46 @@ export function useAuth() {
     }
     const data = await res.json();
     setToken(data.access_token);
-    const u = toUserFromApi(data.user);
+    const u = toUserFromApi(data.user, {
+      activeOrganizationId: data.active_organization_id,
+    });
     setUser(u);
     setSession({ user: u });
+    if (Array.isArray(data.organizations)) setOrganizations(data.organizations);
+    if (data.active_organization_id) setActiveOrganizationId(data.active_organization_id);
     return { user: u, session: { user: u }, requiresConfirmation: false };
+  }, []);
+
+  /** Re-issue the JWT bound to a different organization the caller is a
+   *  member of, then reload so every React Query cache refetches under the
+   *  new tenant. */
+  const switchOrganization = useCallback(async (organizationId: string) => {
+    const token = getToken();
+    const res = await fetch(`${getApiUrl()}/api/auth/switch-org`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ organization_id: organizationId }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.detail || "Failed to switch organization");
+    }
+    const data = await res.json();
+    setToken(data.access_token);
+    const u = toUserFromApi(data.user, {
+      activeOrganizationId: data.active_organization_id,
+    });
+    setUser(u);
+    setSession({ user: u });
+    if (Array.isArray(data.organizations)) setOrganizations(data.organizations);
+    if (data.active_organization_id) setActiveOrganizationId(data.active_organization_id);
+    // Targeted react-query invalidation would require every hook to key
+    // on activeOrganizationId — too invasive for this PR. A hard reload
+    // guarantees a clean cache under the new tenant.
+    window.location.reload();
   }, []);
 
   const logout = useCallback(async () => {
@@ -193,10 +289,16 @@ export function useAuth() {
     isAdmin: !!user && user.role === "admin",
     initializing,
     loginRequired,
+    organizations,
+    activeOrganizationId,
+    /** Current membership role in the active org. Useful for conditionally
+     *  rendering owner/admin-only actions in the UI. */
+    activeRole: user?.activeRole,
     login,
     loginWithUsername,
     register,
     logout,
+    switchOrganization,
     requestPasswordReset,
     updatePassword,
   };

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -5,13 +5,14 @@ import { useAuth } from "@/hooks/useAuth";
 import UsageMonitoring from "@/components/UsageMonitoring";
 import { CredentialsView } from "@/components/CredentialsView";
 import UsersManagement from "@/components/UsersManagement";
-import { Activity, Bot, Database, FolderOpen, PlugZap, Users, ShieldCheck } from "lucide-react";
+import { Activity, Bot, Building2, Database, FolderOpen, PlugZap, Users, ShieldCheck } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SourcesPanel } from "@/components/SourcesPanel";
 import { AddSourceModal } from "@/components/AddSourceModal";
 import { LLMPanel } from "@/components/LLMPanel";
 import { ConnectionsPanel } from "@/components/ConnectionsPanel";
 import AuditTrail from "@/components/AuditTrail";
+import OrganizationPanel from "@/components/OrganizationPanel";
 import { useSearchParams } from "react-router-dom";
 import { dataClient } from "@/services/dataClient";
 import { usePageWalkthrough } from "@/contexts/WalkthroughContext";
@@ -37,6 +38,7 @@ const Account = () => {
       { id: "llm", label: t('account.tabs.llm'), icon: Bot },
       { id: "connections", label: t('account.tabs.connections'), icon: PlugZap },
       ...(loginRequired ? [{ id: "users", label: t('account.tabs.users'), icon: Users }] : []),
+      { id: "organization", label: t('account.tabs.organization') ?? "Organization", icon: Building2 },
       { id: "sources", label: t('account.tabs.sources'), icon: FolderOpen },
       { id: "credentials", label: t('account.tabs.credentials'), icon: Database },
       { id: "audit", label: t('account.tabs.audit'), icon: ShieldCheck },
@@ -106,6 +108,7 @@ const Account = () => {
               {activeSection === "llm" && <LLMPanel hasEnvLlm={hasEnvLlm ?? false} />}
               {activeSection === "connections" && <ConnectionsPanel />}
               {activeSection === "users" && <UsersManagement />}
+              {activeSection === "organization" && <OrganizationPanel />}
               {activeSection === "sources" && (
                 <SourcesPanel
                   onAddSource={() => setShowAddSourceModal(true)}


### PR DESCRIPTION
## Summary

Continuation of #227. That PR merged only the first 3 commits of the multi-tenant work (schema + JWT/scope + enforcement on critical routers). The remaining **11 commits** stayed on the branch and are brought in by this PR.

Nothing here touches the commits already on main — each is an atomic follow-up.

## What's in this PR (11 commits)

### Closing the original 7-commit plan
1. **`feat(security)`** Encrypt `Source.metadata_` secret fields + Telegram/WhatsApp/Slack bot tokens at rest (Fernet envelopes for JSON, `EncryptedText` SQLAlchemy type for scalar columns). Idempotent data migration.
2. **`feat(mcp)`** Remove guest fallback on `/mcp` — API key required always.
3. **`test(tenancy)`** Cross-tenant isolation suite (12 tests: IDOR, role gates, org switching, encryption roundtrip).
4. **`docs(tenancy)`** Operator guide in root + backend `CLAUDE.md`.

### Completing the follow-up 7 commits
5. **`feat(db)`** `organization_id` added to Dashboard, DashboardChart, QASession, Alert, AlertExecution. Migration backfills via parent/user relationships.
6. **`feat(tenancy)`** crud.py filters Dashboard/QASession/Alert by org; INSERT sets `organization_id`; ask.py and alert_scheduler updated.
7. **`feat(tenancy)`** Refactor 20 source-type refresh routers (bigquery, hubspot, snowflake, mongodb, notion, firebase, s3, stripe, jira, pipedrive, salesforce, shopify, intercom, github_analytics, ga4, excel_online, rest_api, sql, dbt, github) from user_id-only to `tenant_filter(Source, scope)`.
8. **`test(tenancy)`** **AST-based CI lint** that fails when an org-scoped model is queried without a tenant filter. Allowlist capped at 14 entries, each with a `why` comment.
9. **`feat(tenancy)`** Organization member management API: `GET/POST/PATCH/DELETE /api/organizations/{id}/members`, `POST /api/organizations`, 7 new tests, last-owner protection.
10. **`feat(tenancy)`** Frontend org switcher in the navigation bar. `useAuth` exposes `organizations`, `activeOrganizationId`, `activeRole`, `switchOrganization()`.
11. **`feat(tenancy)`** Account → Organization settings page with members table, add/remove, role change.

## Test plan

- [x] `pytest tests/test_tenancy.py tests/test_tenancy_lint.py tests/test_storage.py tests/test_crypto.py` — **29 passed** locally
- [x] `npm run typecheck` — clean
- [x] Alembic migrations apply on SQLite (verified locally)
- [ ] CI: the pre-existing failures (sklearn missing from requirements.txt, absent package-lock.json) are unrelated to this PR and have been red on every merge for several PRs already. Worth fixing in a separate hygiene PR.

## Why merge despite red CI

The CI failures that show up on this PR are **identical to the ones already on main** (`c072be25`, `546c79ea`, `e3f2586d`, ...):

- Backend: `ModuleNotFoundError: No module named 'sklearn'` — `sklearn` isn't in `backend/requirements.txt` even though `automl_router` imports it. Pre-existing.
- Frontend: `Dependencies lock file is not found` — `package-lock.json` is gitignored. Pre-existing.

This PR adds **one new lint** (tenancy lint) that passes in isolation and does **not** regress the other failures.

## Rollout notes

- Same as #227: existing deploys upgrade safely via migrations; JWT tokens issued before the `org_id` claim still resolve via first-membership fallback; guest mode still works and the guest user is now auto-enrolled as owner of a `Guest` org by the #227 migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)