### PR TITLE
fix(ask): stale user refs + SQLite lock during LLM call

### DIFF
--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -907,7 +907,7 @@ async def ask_question(
     # When workspace uses "Default (env/config)", llm_config_id is null -> prefer env so .env wins over stale LlmSettings
     llm_overrides = None
     if agent.llm_config_id:
-        r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id, LlmConfig.user_id == user.id))
+        r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id, LlmConfig.user_id == scope.user.id))
         cfg = r_cfg.scalar_one_or_none()
         if cfg:
             llm_overrides = _llm_config_to_overrides(cfg)
@@ -944,7 +944,7 @@ async def ask_question(
         question=body.question,
         agent=agent,
         sources=sources,
-        user=user,
+        user=scope.user,
         db=db,
         llm_overrides=llm_overrides,
         history=history,
@@ -970,7 +970,7 @@ async def generate_chart_for_turn(
     db: AsyncSession = Depends(get_db),
     scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(QASession).where(QASession.id == session_id, tenant_filter(QASession, scope), QASession.user_id == user.id))
+    r = await db.execute(select(QASession).where(QASession.id == session_id, tenant_filter(QASession, scope), QASession.user_id == scope.user.id))
     qa = r.scalar_one_or_none()
     if not qa:
         raise HTTPException(404, "Session not found")
@@ -993,7 +993,7 @@ async def generate_chart_for_turn(
 
     llm_overrides = None
     if agent.llm_config_id:
-        r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id, LlmConfig.user_id == user.id))
+        r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id, LlmConfig.user_id == scope.user.id))
         cfg = r_cfg.scalar_one_or_none()
         if cfg:
             llm_overrides = _llm_config_to_overrides(cfg)
@@ -1037,14 +1037,14 @@ async def get_chart_image(
     db: AsyncSession = Depends(get_db),
     scope: TenantScope = Depends(require_membership),
 ):
-    r = await db.execute(select(QASession).where(QASession.id == session_id, tenant_filter(QASession, scope), QASession.user_id == user.id))
+    r = await db.execute(select(QASession).where(QASession.id == session_id, tenant_filter(QASession, scope), QASession.user_id == scope.user.id))
     qa = r.scalar_one_or_none()
     if not qa:
         raise HTTPException(404, "Session not found")
 
     history = qa.conversation_history or []
     _find_turn(history, turn_id, None)
-    _, full_path = _chart_file_path(user.id, session_id, turn_id)
+    _, full_path = _chart_file_path(scope.user.id, session_id, turn_id)
     if not full_path.exists():
         raise HTTPException(404, "Chart image not found")
 

--- a/backend/app/services/lineage.py
+++ b/backend/app/services/lineage.py
@@ -52,7 +52,11 @@ async def start_run(
             metadata_=metadata or {},
         )
         db.add(run)
-        await db.flush()
+        # Deliberately no flush here. On SQLite, an eager flush opens a
+        # write transaction that blocks concurrent sessions (the LLM call
+        # log writer runs in a separate session); the row will flush
+        # naturally when the caller commits. We keep `run.id` assigned
+        # client-side so record_edge can still reference it.
         return run
     except Exception:  # noqa: BLE001 — instrumentation must not break callers
         logger.exception("Failed to start lineage run")
@@ -82,7 +86,8 @@ async def finish_run(
             merged = dict(run.metadata_ or {})
             merged.update(metadata_extra)
             run.metadata_ = merged
-        await db.flush()
+        # Same reasoning as start_run: no eager flush so we don't hold a
+        # write lock while the rest of the request is running.
     except Exception:  # noqa: BLE001
         logger.exception("Failed to finish lineage run")
 
@@ -105,6 +110,7 @@ async def record_edge(
         edge = LineageEdge(
             id=str(uuid.uuid4()),
             run_id=run.id,
+            organization_id=getattr(run, "organization_id", None) or "",
             source_kind=source_kind,
             source_ref=source_ref[:512] if source_ref else "",
             target_kind=target_kind,
@@ -113,7 +119,7 @@ async def record_edge(
             metadata_=metadata or {},
         )
         db.add(edge)
-        await db.flush()
+        # No eager flush here either — see start_run for the reason.
     except Exception:  # noqa: BLE001
         logger.exception("Failed to record lineage edge")
 


### PR DESCRIPTION
Two bugs breaking ask-question after the multi-tenant refactor.

1. **NameError**: sed refactor left 6 bare `user.id` references in the three HTTP handlers (`ask_question`, `generate_chart_for_turn`, `get_chart_image`) while renaming the dependency to `scope`. Every POST /api/ask-question hit 500.

2. **SQLite lock**: the lineage tracker called `db.flush()` eagerly in `start_run`/`record_edge`/`finish_run`, opening a write transaction that blocked the LLM-call logger (which runs in a separate session). "database is locked" after ~30s.

Fix: rename the stragglers to `scope.user.id`, drop the eager flushes (rows persist when the outer request commits at the end). Verified live: `POST /api/ask-question` returns 200 with a real LLM answer in guest mode. 38/38 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)