### PR TITLE
feat(llm): per-config Test button in Settings → LLM panel

### DIFF
--- a/backend/app/routers/settings_router.py
+++ b/backend/app/routers/settings_router.py
@@ -570,3 +570,86 @@ async def delete_llm_config(
     await db.commit()
     await _auto_default_if_single(user.id, db)
     return {"ok": True}
+
+
+@router.post("/llm-configs/{config_id}/test")
+async def test_llm_config(
+    config_id: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    """Run a tiny live chat completion against the saved credentials and
+    return `{ok, latency_ms, provider, model, reply?, error?}`.
+
+    Used by the "Test" button in the Settings → LLM panel so the user
+    can verify a configuration before pointing a workspace at it. We do
+    NOT store the result — stateless health check.
+    """
+    import time
+
+    from app.llm.client import chat_completion
+    from app.routers.ask import _llm_config_to_overrides
+
+    r = await db.execute(
+        select(LlmConfig).where(LlmConfig.id == config_id, LlmConfig.user_id == user.id)
+    )
+    cfg = r.scalar_one_or_none()
+    if not cfg:
+        raise HTTPException(404, "LLM config not found")
+
+    overrides = _llm_config_to_overrides(cfg) or {}
+    provider = overrides.get("llm_provider") or cfg.llm_provider
+    model = (
+        overrides.get(f"{provider}_model")
+        or overrides.get("openai_model")
+        or ""
+    )
+
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are a connectivity test probe. Respond with a single short "
+                "sentence confirming the LLM is reachable."
+            ),
+        },
+        {"role": "user", "content": "Ping. Reply with a brief confirmation."},
+    ]
+
+    start = time.monotonic()
+    try:
+        reply, _usage, _trace = await chat_completion(
+            messages=messages,
+            llm_overrides=overrides,
+            max_tokens=64,
+        )
+        latency_ms = int((time.monotonic() - start) * 1000)
+        return {
+            "ok": True,
+            "latency_ms": latency_ms,
+            "provider": provider,
+            "model": model or None,
+            "reply": (reply or "").strip()[:400],
+        }
+    except Exception as e:  # noqa: BLE001 — translate to a UI-friendly error
+        latency_ms = int((time.monotonic() - start) * 1000)
+        # Normalize the most common failure modes into short messages.
+        raw = str(e) or e.__class__.__name__
+        lowered = raw.lower()
+        if "api key" in lowered or "unauthorized" in lowered or "401" in lowered:
+            msg = "Invalid or missing API key."
+        elif "model" in lowered and ("not found" in lowered or "does not exist" in lowered):
+            msg = f"Model '{model}' is not available for this provider."
+        elif "timeout" in lowered or "timed out" in lowered:
+            msg = "Request timed out."
+        elif "connection" in lowered or "network" in lowered:
+            msg = "Network error reaching the provider."
+        else:
+            msg = raw[:400]
+        return {
+            "ok": False,
+            "latency_ms": latency_ms,
+            "provider": provider,
+            "model": model or None,
+            "error": msg,
+        }

--- a/src/components/LLMPanel.tsx
+++ b/src/components/LLMPanel.tsx
@@ -13,7 +13,7 @@ import {
 import { toast } from "sonner";
 import { dataClient } from "@/services/dataClient";
 import { useLanguage } from "@/contexts/LanguageContext";
-import { Bot, Loader2, Pencil, Plus, RefreshCw, Star, Trash2 } from "lucide-react";
+import { Bot, CheckCircle2, Loader2, Pencil, Plus, Plug, RefreshCw, Star, Trash2, XCircle } from "lucide-react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -307,6 +307,49 @@ export function LLMPanel({ hasEnvLlm, onConfigAdded }: LLMPanelProps = {}) {
     }
   };
 
+  // Per-config test state: id → ok + latency/error, so each row renders its
+  // own badge without blocking the others. `running` set controls spinners.
+  const [testResults, setTestResults] = useState<
+    Record<string, { ok: boolean; latency_ms: number; model?: string | null; error?: string; reply?: string }>
+  >({});
+  const [testingIds, setTestingIds] = useState<Set<string>>(new Set());
+
+  const handleTest = async (id: string) => {
+    setTestingIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+    try {
+      const result = await dataClient.testLlmConfig(id);
+      setTestResults((prev) => ({ ...prev, [id]: result }));
+      if (result.ok) {
+        toast.success(
+          t("llmConfig.testSucceeded") ?? "Connection successful",
+          { description: `${result.latency_ms} ms · ${result.model ?? result.provider}` },
+        );
+      } else {
+        toast.error(
+          t("llmConfig.testFailed") ?? "Connection failed",
+          { description: result.error ?? "Unknown error" },
+        );
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      setTestResults((prev) => ({
+        ...prev,
+        [id]: { ok: false, latency_ms: 0, error: msg },
+      }));
+      toast.error(t("llmConfig.testFailed") ?? "Connection failed", { description: msg });
+    } finally {
+      setTestingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
+
   const isApiKeyMasked = (val: string) => val && val.includes("••••");
 
   const formFields = (
@@ -589,6 +632,40 @@ export function LLMPanel({ hasEnvLlm, onConfigAdded }: LLMPanelProps = {}) {
                           )}
                         </div>
                       </div>
+                      {(() => {
+                        const result = testResults[cfg.id];
+                        const isRunning = testingIds.has(cfg.id);
+                        const titleBase = t("llmConfig.test") ?? "Test connection";
+                        const title = result
+                          ? result.ok
+                            ? `${titleBase} — ${result.latency_ms} ms`
+                            : `${titleBase} — ${result.error ?? "failed"}`
+                          : titleBase;
+                        const Icon = isRunning
+                          ? Loader2
+                          : result?.ok
+                            ? CheckCircle2
+                            : result
+                              ? XCircle
+                              : Plug;
+                        const colorClass = result?.ok
+                          ? "text-emerald-500"
+                          : result
+                            ? "text-destructive"
+                            : "";
+                        return (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className={`h-6 w-6 transition-opacity ${result ? "opacity-100" : "opacity-0 group-hover:opacity-100"} ${colorClass}`}
+                            title={title}
+                            disabled={isRunning}
+                            onClick={() => handleTest(cfg.id)}
+                          >
+                            <Icon className={`h-4 w-4 ${isRunning ? "animate-spin" : ""}`} />
+                          </Button>
+                        );
+                      })()}
                       <Button
                         variant="ghost"
                         size="icon"

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -874,6 +874,21 @@ export const apiClient = {
     return api(`/api/settings/llm-configs/${id}`, { method: 'DELETE' });
   },
 
+  /** Run a live ping against a saved LLM config.
+   *  Returns `{ok, latency_ms, provider, model, reply?, error?}`. Used by
+   *  the Test button in Settings → LLM so the user can verify creds
+   *  before pointing a workspace at the config. */
+  async testLlmConfig(id: string) {
+    return api<{
+      ok: boolean;
+      latency_ms: number;
+      provider: string;
+      model?: string | null;
+      reply?: string;
+      error?: string;
+    }>(`/api/settings/llm-configs/${id}/test`, { method: 'POST' });
+  },
+
   // Studio Summary (table executive reports)
   async generateTableSummary(agentId: string, sourceId?: string, language?: string) {
     return api<{


### PR DESCRIPTION
Adds a live connectivity check so users can verify a saved LLM config before pointing a workspace at it.

## Backend
New `POST /api/settings/llm-configs/{id}/test` endpoint. Reuses `chat_completion` + `_llm_config_to_overrides` so the test path matches the real Q&A path exactly. Returns `{ok, latency_ms, provider, model, reply?, error?}`. Errors normalized into short UI-friendly messages ("Invalid or missing API key", "Model 'X' is not available", "Request timed out", "Network error").

## Frontend
- `apiClient.testLlmConfig(id)` typed helper.
- `LLMPanel` renders a small icon button per row:
  - idle: Plug (hover-only)
  - running: Loader2 spinning
  - success: CheckCircle2 emerald (persisted)
  - failure: XCircle destructive (persisted)
- Tooltip shows the result; toast surfaces latency + model (success) or normalized error (failure).

## Verified
Live smoke with a deliberately invalid OpenAI key → `{"ok":false,"latency_ms":1367,"provider":"openai","model":"gpt-4o-mini","error":"Invalid or missing API key."}`. `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)