### PR TITLE
fix(llm): claude-code reliability (stdin pipe, error extraction, test prompt)

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -359,22 +359,77 @@ async def _claude_code_chat(messages: list[dict[str, str]], max_tokens: int, cfg
         env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
 
     # ── Build CLI args ──
-    args = [claude_bin, "-p", prompt, "--output-format", "stream-json", "--verbose"]
+    # We pipe the prompt via stdin instead of `-p "<prompt>"` because ETL/Q&A
+    # prompts can easily exceed the OS argv limit (256 KB on macOS, ~2 MB on
+    # Linux). With `-p ""` and stdin the prompt size is bounded only by the
+    # CLI's own context window.
+    args = [
+        claude_bin,
+        "-p", "",
+        "--output-format", "stream-json",
+        "--verbose",
+    ]
     if model:
         args.extend(["--model", model])
 
     # ── Execute subprocess ──
     proc = await asyncio.create_subprocess_exec(
         *args,
+        stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=env,
     )
 
-    stdout_data, stderr_data = await proc.communicate()
+    stdout_data, stderr_data = await proc.communicate(input=prompt.encode("utf-8"))
 
-    if proc.returncode != 0:
+    # Helper: pull any error message embedded in the stream-json stdout
+    # (the CLI emits auth failures, rate-limit hits, and other API errors
+    # there even when the process exits non-zero with empty stderr).
+    def _extract_stream_json_error(raw: bytes) -> str:
+        text = raw.decode("utf-8", errors="replace")
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = _json.loads(line)
+            except _json.JSONDecodeError:
+                continue
+            # Result lines flag explicit failures
+            if obj.get("type") == "result" and obj.get("is_error"):
+                msg = obj.get("result") or obj.get("text") or ""
+                if msg:
+                    return str(msg).strip()
+            # Assistant lines may carry an `error` slug + message
+            if obj.get("type") == "assistant" and obj.get("error"):
+                inner = obj.get("message", {}).get("content") or []
+                for blk in inner:
+                    if blk.get("type") == "text" and blk.get("text"):
+                        return str(blk["text"]).strip()
+            # System/setup error
+            if obj.get("type") == "error":
+                return str(obj.get("message") or obj.get("error") or line).strip()
+        return ""
+
+    # Even when the CLI exits 0, a stream-json result with `is_error: true`
+    # means the call failed (auth, rate limit, etc). Surface those as
+    # explicit errors so the caller doesn't see an empty answer.
+    embedded = _extract_stream_json_error(stdout_data)
+
+    if proc.returncode != 0 or embedded:
         err_text = stderr_data.decode("utf-8", errors="replace").strip()
+        # Prefer the structured stdout message; fall back to stderr; then to
+        # a hint about authentication if both are empty (most common cause
+        # of exit 1 with no output is a missing/expired OAuth token).
+        if embedded:
+            err_text = embedded
+        elif not err_text:
+            err_text = (
+                "Claude CLI exited with no output. The most common cause is a "
+                "missing or expired OAuth token — run `claude login` from a "
+                "terminal, or set CLAUDE_CODE_OAUTH_TOKEN in backend/.env."
+            )
         raise RuntimeError(f"Claude CLI exited with code {proc.returncode}: {err_text}")
 
     # ── Parse stream-json output ──

--- a/backend/app/routers/settings_router.py
+++ b/backend/app/routers/settings_router.py
@@ -605,15 +605,12 @@ async def test_llm_config(
         or ""
     )
 
+    # Plain ping. Earlier versions of this prompt tried to roleplay the
+    # assistant as a "connectivity probe", which the Claude CLI's guard
+    # flagged as a prompt-injection attempt and refused. A simple
+    # arithmetic question is unambiguous and works on every provider.
     messages = [
-        {
-            "role": "system",
-            "content": (
-                "You are a connectivity test probe. Respond with a single short "
-                "sentence confirming the LLM is reachable."
-            ),
-        },
-        {"role": "user", "content": "Ping. Reply with a brief confirmation."},
+        {"role": "user", "content": "Reply with the digit 4 only. What is 2+2?"}
     ]
 
     start = time.monotonic()


### PR DESCRIPTION
Three bugs converging into `Claude CLI exited with code 1:` with empty stderr.

## 1. Empty error on non-zero exit
The CLI emits real failure reasons (auth, rate limit, model not found) as a stream-json `result` line with `is_error:true` on stdout. Our wrapper only read stderr → empty. Now we walk stdout for `is_error:true` and surface that text. Fall back to a hint about `claude login` / `CLAUDE_CODE_OAUTH_TOKEN` when both channels are empty. Also raise when exit-0 but stdout flagged `is_error`, instead of returning an empty reply.

## 2. ARG_MAX overflow on real prompts
`-p "<prompt>"` puts the entire prompt on argv. macOS caps argv at 256 KB; ETL/Q&A prompts with sample rows blow past that, so the subprocess silently exits 1. Switched to `-p ""` + stdin via `proc.communicate(input=...)`. Verified ask-question against an 8,807-row CSV via claude-code — was 500, now 200.

## 3. Test endpoint refused by prompt-injection guard
The probe prompt ("You are a connectivity test probe…") read like a jailbreak to Claude Code's guard, which replied refusing it. Plain arithmetic ping ("What is 2+2?") works everywhere. Test endpoint now returns `{"ok":true,"reply":"4"}` for claude-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)