### PR TITLE
fix(ui): Usage report layout, Organization i18n key, language selector cleanup

### DIFF
--- a/src/components/UsageMonitoring.tsx
+++ b/src/components/UsageMonitoring.tsx
@@ -136,10 +136,15 @@ const UsageMonitoring = () => {
       </div>
     );
   }
-  return <div className="h-full flex flex-col space-y-3">
-      
-      
-      <div className="grid gap-3 md:grid-cols-4 flex-shrink-0">
+  // Normal block flow inside the Account page's `overflow-y-auto` scroll
+  // container. The previous `h-full flex flex-col` layout combined with a
+  // `flex-1` chart card greedily consumed remaining height — fine when the
+  // chart was the only thing below the stat cards, but as soon as the AI
+  // Usage section was rendered underneath the chart card pushed up and
+  // overlapped it. Pure stacked sections solve the issue.
+  return <div className="space-y-4">
+
+      <div className="grid gap-3 md:grid-cols-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
@@ -198,13 +203,13 @@ const UsageMonitoring = () => {
         </Card>
       </div>
 
-      <Card className="flex-1 flex flex-col min-h-0">
+      <Card>
         <CardHeader>
           <CardTitle>
             {language === 'pt' ? 'Perguntas por Dia' : 'Questions per Day'}
           </CardTitle>
         </CardHeader>
-        <CardContent className="flex-1 min-h-0 pt-0 pb-4 px-2 sm:px-4">
+        <CardContent className="pt-0 pb-4 px-2 sm:px-4">
           {dailyQuestions.length > 0 ? (
             <ChartContainer
               config={{
@@ -213,7 +218,7 @@ const UsageMonitoring = () => {
                   color: "hsl(var(--primary))",
                 },
               }}
-              className="w-full h-[260px] sm:h-[320px] md:h-[400px]"
+              className="w-full h-[260px] sm:h-[320px] md:h-[360px]"
             >
               <BarChart data={dailyQuestions} margin={{ top: 10, right: 24, bottom: 28, left: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
@@ -235,7 +240,7 @@ const UsageMonitoring = () => {
               </BarChart>
             </ChartContainer>
           ) : (
-            <div className="h-full min-h-[400px] flex items-center justify-center text-muted-foreground">
+            <div className="h-[260px] sm:h-[320px] md:h-[360px] flex items-center justify-center text-muted-foreground">
               {language === 'pt' ? 'Nenhuma pergunta nos últimos 30 dias' : 'No questions in the last 30 days'}
             </div>
           )}
@@ -249,7 +254,7 @@ const UsageMonitoring = () => {
             {language === 'pt' ? 'Uso de IA (últimos 30 dias)' : 'AI Usage (last 30 days)'}
           </h3>
 
-          <div className="grid gap-3 md:grid-cols-4 flex-shrink-0">
+          <div className="grid gap-3 md:grid-cols-4">
             <Card>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">{language === 'pt' ? 'Chamadas IA' : 'AI Calls'}</CardTitle>

--- a/src/components/ui/language-selector.tsx
+++ b/src/components/ui/language-selector.tsx
@@ -1,4 +1,3 @@
-import { Globe } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -22,9 +21,16 @@ const LanguageSelector = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" className="gap-2">
-          <Globe className="h-4 w-4" />
-          <span className="hidden sm:inline">{currentLanguage?.flag}</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label={currentLanguage?.name ?? "Language"}
+          className="px-2"
+        >
+          {/* Flag-only trigger. The globe icon was redundant — the flag
+              already conveys "language" and reduced visual noise in the
+              top bar. */}
+          <span className="text-base leading-none">{currentLanguage?.flag}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -614,6 +614,7 @@ const translations = {
       'account.tabs.credentials': 'Credentials',
       'account.tabs.connections': 'Connections',
       'account.tabs.users': 'Users',
+      'account.tabs.organization': 'Organization',
       'account.tabs.audit': 'Audit Trail',
     // Audit Trail
     'audit.title': 'Audit Trail',
@@ -2166,6 +2167,7 @@ const translations = {
       'account.tabs.credentials': 'Credenciais',
       'account.tabs.connections': 'Connections',
       'account.tabs.users': 'Usuários',
+      'account.tabs.organization': 'Organização',
       'account.tabs.audit': 'Trilha de Auditoria',
     // Audit Trail
     'audit.title': 'Trilha de Auditoria',
@@ -3204,6 +3206,7 @@ const translations = {
     'account.tabs.credentials': 'Credenciales',
     'account.tabs.connections': 'Connections',
     'account.tabs.users': 'Usuarios',
+    'account.tabs.organization': 'Organización',
     'account.tabs.audit': 'Auditoría',
     // Audit Trail
     'audit.title': 'Registro de Auditoría',


### PR DESCRIPTION
Three small UI fixes batched.

1. **Usage report layout collapsed** when the AI Usage section appeared. The 'Questions per Day' card was `flex-1` greedily eating remaining height; once the AI Usage section rendered below, content overlapped. Switched to plain stacked block flow + the parent's existing `overflow-y-auto`.

2. **Sidebar showed `account.tabs.organization` literal**. Added the i18n entries in en/pt/es — `t()` returns the key when missing, so the `?? "Organization"` fallback I had before never fired.

3. **Language selector**: dropped the globe icon, kept only the flag emoji. The flag already conveys 'language picker' and the globe was visual noise. `aria-label` set to the current language name for screen readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)