### PR TITLE
fix(dev): Vite default port 8080 → 5173 with strictPort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ make run
 make migrate
 
 # Frontend only
-npm run dev          # Dev server on :8080
+npm run dev          # Dev server on :5173
 npm run build        # Production build
 npm run lint         # ESLint
 npm test             # Vitest
@@ -147,7 +147,7 @@ Role is per-`OrganizationMembership`, so the same user may be `admin` in org A a
 
 ## Common Pitfalls
 
-- The frontend dev server runs on port **8080**, backend on **8000**. Vite proxies API calls via `VITE_API_URL`.
+- The frontend dev server runs on port **5173** (Vite default), backend on **8000**. Vite proxies API calls via `VITE_API_URL`. Port 8080 was the previous default but conflicts with common local services (Firestore emulator, Tomcat, Jenkins).
 - SQLAlchemy models are all in a single `models.py` file — keep it that way.
 - Charts are generated server-side (matplotlib) and served as images, not rendered in the frontend.
 - The `dist/` folder is served by FastAPI as static files in production mode.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ To develop the frontend with hot reload:
 
 1. Backend running (as above).
 2. From the project root: create `.env.local` with `VITE_API_URL=http://localhost:8000`, then `npm install` and `npm run dev`.
-3. Open [http://localhost:8080](http://localhost:8080).
+3. Open [http://localhost:5173](http://localhost:5173).
 
 ## How to use
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ```bash
 npm install              # Install dependencies
-npm run dev              # Dev server on http://localhost:8080
+npm run dev              # Dev server on http://localhost:5173
 npm run build            # Production build to dist/
 npm run lint             # ESLint
 npm test                 # Vitest (run once)
@@ -109,7 +109,7 @@ import { Button } from "../../components/ui/button";
 
 ## Common Pitfalls
 
-- Dev server is on port **8080** (not 3000 or 5173). Configured in `vite.config.ts`.
+- Dev server is on port **5173** (Vite default). Configured in `vite.config.ts` with `strictPort: true`, so a port collision fails loudly instead of silently falling back to a different port. The previous default (8080) clashed with Firestore emulator / Tomcat / Jenkins.
 - `VITE_API_URL` must point to the backend (default: `http://localhost:8000`).
 - Charts are server-rendered images — the frontend just displays `<img>` tags, not chart libraries.
 - The `dist/` folder is what FastAPI serves in production; do not rely on Vite in prod.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,8 +28,14 @@ export default defineConfig(({ command }) => {
   return {
     server: {
       host: "::",
-      port: 8080,
-      strictPort: false,
+      // Default to 5173 (Vite's own default) instead of 8080. Port 8080 is
+      // notoriously contested — Firebase Firestore emulator, Tomcat, Jenkins,
+      // most local Java apps default there — and Vite's silent fallback to
+      // a free port left users hitting whatever service was actually on 8080
+      // and seeing a stale "Ok" response or worse. `strictPort: true` makes
+      // a port collision fail loudly so the developer notices.
+      port: 5173,
+      strictPort: true,
       proxy: {
         "/api": {
           target: backendUrl,


### PR DESCRIPTION
Port 8080 conflicts with the Firebase Firestore emulator (which the user happened to be running for an unrelated project — `dentistalk`), Tomcat, Jenkins, and most JVM dev servers. With `strictPort: false`, Vite silently fell back to a different free port when 8080 was taken, so the user opened 8080 themselves, hit whatever was on that port, and saw a 3-byte "Ok" response.

Fix: default to 5173 (Vite's own default, conflict-rare) and set `strictPort: true` so future collisions fail loudly. Docs updated.

## Verified

- `npm run dev` binds to 5173 cleanly.
- HTML index, App.tsx, LanguageContext.tsx, LLMPanel.tsx, OrganizationPanel.tsx all serve 200 via the dev server.
- API proxy returns the expected guest payload from the backend through the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)