### PR TITLE
fix(tenancy): stale user.* refs in handlers that switched to TenantScope

### DIFF
--- a/backend/app/routers/api_keys_router.py
+++ b/backend/app/routers/api_keys_router.py
@@ -64,7 +64,7 @@ async def create_api_key(
     raw_key = _generate_raw_key()
     api_key = ApiKey(
         id=str(uuid.uuid4()),
-        user_id=user.id,
+        user_id=scope.user.id,
         agent_id=body.agent_id,
         name=body.name,
         key_hash=_hash_api_key(raw_key),

--- a/backend/app/routers/automl_router.py
+++ b/backend/app/routers/automl_router.py
@@ -48,14 +48,14 @@ def _user_llm_overrides(llm_row: LlmSettings | LlmConfig | None) -> dict | None:
     return overrides if overrides else None
 
 
-async def _resolve_llm_overrides(db: AsyncSession, user: User, agent: Agent) -> dict | None:
+async def _resolve_llm_overrides(db: AsyncSession, scope: "TenantScope", agent: Agent) -> dict | None:
     """Resolve LLM config: agent-level config > user settings > env."""
     if agent.llm_config_id:
         r = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id))
         config = r.scalar_one_or_none()
         if config:
             return _user_llm_overrides(config)
-    r = await db.execute(select(LlmSettings).where(LlmSettings.user_id == user.id))
+    r = await db.execute(select(LlmSettings).where(LlmSettings.user_id == scope.user.id))
     return _user_llm_overrides(r.scalar_one_or_none())
 
 
@@ -164,7 +164,7 @@ async def train_automl(
     if not source:
         raise HTTPException(404, "Source not found")
 
-    llm_overrides = await _resolve_llm_overrides(db, user, agent)
+    llm_overrides = await _resolve_llm_overrides(db, scope, agent)
 
     df = _load_source_dataframe(source)
     result = await run_automl(
@@ -177,7 +177,7 @@ async def train_automl(
     run_id = str(uuid.uuid4())
     run = AutoMLRun(
         id=run_id,
-        user_id=user.id,
+        user_id=scope.user.id,
         agent_id=body.agentId,
         source_id=source.id,
         source_name=source.name,
@@ -221,7 +221,7 @@ async def list_runs(
     """List Auto ML runs, optionally filtered by workspace."""
     q = (
         select(AutoMLRun)
-        .where(AutoMLRun.user_id == user.id)
+        .where(AutoMLRun.user_id == scope.user.id)
         .order_by(AutoMLRun.created_at.desc())
     )
     if agent_id:
@@ -238,7 +238,7 @@ async def get_run(
 ):
     """Get a single Auto ML run."""
     r = await db.execute(
-        select(AutoMLRun).where(AutoMLRun.id == run_id, AutoMLRun.user_id == user.id)
+        select(AutoMLRun).where(AutoMLRun.id == run_id, AutoMLRun.user_id == scope.user.id)
     )
     run = r.scalar_one_or_none()
     if not run:
@@ -254,7 +254,7 @@ async def delete_run(
 ):
     """Delete an Auto ML run."""
     r = await db.execute(
-        select(AutoMLRun).where(AutoMLRun.id == run_id, AutoMLRun.user_id == user.id)
+        select(AutoMLRun).where(AutoMLRun.id == run_id, AutoMLRun.user_id == scope.user.id)
     )
     run = r.scalar_one_or_none()
     if not run:

--- a/backend/app/routers/cdp_router.py
+++ b/backend/app/routers/cdp_router.py
@@ -45,7 +45,7 @@ class CdpSegmentRequest(BaseModel):
     enrichedSchema: Optional[dict] = None
 
 
-async def _get_agent_and_llm(agent_id: str, user: User, db: AsyncSession):
+async def _get_agent_and_llm(agent_id: str, scope: "TenantScope", db: AsyncSession):
     r = await db.execute(select(Agent).where(Agent.id == agent_id, tenant_filter(Agent, scope)))
     agent = r.scalar_one_or_none()
     if not agent:
@@ -69,7 +69,7 @@ async def suggest_identity_resolution(
     db: AsyncSession = Depends(get_db),
 ):
     """AI suggests how to unify customer records across sources."""
-    agent, llm_overrides = await _get_agent_and_llm(body.agentId, user, db)
+    agent, llm_overrides = await _get_agent_and_llm(body.agentId, scope, db)
 
     # Load all active sources for this workspace
     r = await db.execute(
@@ -102,7 +102,7 @@ async def suggest_enrichment(
     db: AsyncSession = Depends(get_db),
 ):
     """AI suggests customer metrics to calculate."""
-    agent, llm_overrides = await _get_agent_and_llm(body.agentId, user, db)
+    agent, llm_overrides = await _get_agent_and_llm(body.agentId, scope, db)
 
     config = agent.workspace_config or {}
     unified_schema = body.unifiedSchema or config.get("identity_resolution", {})
@@ -130,7 +130,7 @@ async def suggest_segmentation(
     db: AsyncSession = Depends(get_db),
 ):
     """AI suggests customer segmentation rules."""
-    agent, llm_overrides = await _get_agent_and_llm(body.agentId, user, db)
+    agent, llm_overrides = await _get_agent_and_llm(body.agentId, scope, db)
 
     config = agent.workspace_config or {}
     enriched_schema = body.enrichedSchema or config.get("enrichment", {})
@@ -259,7 +259,7 @@ async def materialize_cdp_table(
     # when configured. We first materialize to a local cache path so pandas
     # can write directly to disk, then hand the bytes to storage to mirror
     # the write to S3.
-    output_filename = f"{user.id}/{uuid.uuid4().hex[:8]}_{body.tableName}.csv"
+    output_filename = f"{scope.user.id}/{uuid.uuid4().hex[:8]}_{body.tableName}.csv"
     import io as _io
     buf = _io.BytesIO()
     result_df.to_csv(buf, index=False)
@@ -280,8 +280,8 @@ async def materialize_cdp_table(
     # Create new Source in DB
     source = Source(
         id=str(uuid.uuid4()),
-        user_id=user.id,
-        organization_id=user.organization_id or user.id,
+        user_id=scope.user.id,
+        organization_id=scope.organization_id or scope.user.id,
         agent_id=agent.id,
         name=f"{body.tableName}.csv",
         type="csv",

--- a/backend/app/routers/organizations_router.py
+++ b/backend/app/routers/organizations_router.py
@@ -145,7 +145,7 @@ async def add_member(
     r = await db.execute(
         select(OrganizationMembership).where(
             OrganizationMembership.organization_id == organization_id,
-            OrganizationMembership.user_id == user.id,
+            OrganizationMembership.user_id == scope.user.id,
         )
     )
     if r.scalar_one_or_none():
@@ -154,14 +154,14 @@ async def add_member(
     m = OrganizationMembership(
         id=str(uuid.uuid4()),
         organization_id=organization_id,
-        user_id=user.id,
+        user_id=scope.user.id,
         role=body.role,
     )
     db.add(m)
     await db.commit()
     return {
-        "user_id": user.id,
-        "email": user.email,
+        "user_id": scope.user.id,
+        "email": scope.user.email,
         "role": body.role,
     }
 

--- a/backend/app/routers/report_router.py
+++ b/backend/app/routers/report_router.py
@@ -111,7 +111,7 @@ async def generate_report(
     # Same resolution logic as the ask router
     llm_overrides = None
     if agent.llm_config_id:
-        r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id, LlmConfig.user_id == user.id))
+        r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id, LlmConfig.user_id == scope.user.id))
         cfg = r_cfg.scalar_one_or_none()
         if cfg:
             llm_overrides = _llm_config_to_overrides(cfg)
@@ -187,7 +187,7 @@ async def generate_report(
     report_id = str(uuid.uuid4())
     report = Report(
         id=report_id,
-        user_id=user.id,
+        user_id=scope.user.id,
         agent_id=body.agentId,
         source_id=source.id,
         source_name=source.name,
@@ -214,7 +214,7 @@ async def list_reports(
     scope: TenantScope = Depends(require_membership),
 ):
     """List reports, optionally filtered by workspace (agent_id)."""
-    q = select(Report).where(Report.user_id == user.id).order_by(Report.created_at.desc())
+    q = select(Report).where(Report.user_id == scope.user.id).order_by(Report.created_at.desc())
     if agent_id:
         q = q.where(Report.agent_id == agent_id)
     r = await db.execute(q)
@@ -239,7 +239,7 @@ async def get_report(
     scope: TenantScope = Depends(require_membership),
 ):
     """Get a single report by id (metadata only, no HTML content)."""
-    r = await db.execute(select(Report).where(Report.id == report_id, Report.user_id == user.id))
+    r = await db.execute(select(Report).where(Report.id == report_id, Report.user_id == scope.user.id))
     rpt = r.scalar_one_or_none()
     if not rpt:
         raise HTTPException(404, "Report not found")
@@ -260,7 +260,7 @@ async def get_report_html(
     scope: TenantScope = Depends(require_membership),
 ):
     """Serve the HTML content of a report (for iframe or download)."""
-    r = await db.execute(select(Report).where(Report.id == report_id, Report.user_id == user.id))
+    r = await db.execute(select(Report).where(Report.id == report_id, Report.user_id == scope.user.id))
     rpt = r.scalar_one_or_none()
     if not rpt:
         raise HTTPException(404, "Report not found")
@@ -274,7 +274,7 @@ async def delete_report(
     scope: TenantScope = Depends(require_membership),
 ):
     """Delete a report."""
-    r = await db.execute(select(Report).where(Report.id == report_id, Report.user_id == user.id))
+    r = await db.execute(select(Report).where(Report.id == report_id, Report.user_id == scope.user.id))
     rpt = r.scalar_one_or_none()
     if not rpt:
         raise HTTPException(404, "Report not found")

--- a/backend/app/routers/summary_router.py
+++ b/backend/app/routers/summary_router.py
@@ -90,7 +90,7 @@ async def generate_summary(
     # Same resolution logic as the ask router
     llm_overrides = None
     if agent.llm_config_id:
-        r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id, LlmConfig.user_id == user.id))
+        r_cfg = await db.execute(select(LlmConfig).where(LlmConfig.id == agent.llm_config_id, LlmConfig.user_id == scope.user.id))
         cfg = r_cfg.scalar_one_or_none()
         if cfg:
             llm_overrides = _llm_config_to_overrides(cfg)
@@ -173,7 +173,7 @@ async def generate_summary(
     summary_id = str(uuid.uuid4())
     summary = TableSummary(
         id=summary_id,
-        user_id=user.id,
+        user_id=scope.user.id,
         agent_id=body.agentId,
         source_id=source.id,
         source_name=source.name,
@@ -201,7 +201,7 @@ async def list_summaries(
     scope: TenantScope = Depends(require_membership),
 ):
     """List table summaries, optionally filtered by workspace (agent_id)."""
-    q = select(TableSummary).where(TableSummary.user_id == user.id).order_by(TableSummary.created_at.desc())
+    q = select(TableSummary).where(TableSummary.user_id == scope.user.id).order_by(TableSummary.created_at.desc())
     if agent_id:
         q = q.where(TableSummary.agent_id == agent_id)
     r = await db.execute(q)
@@ -227,7 +227,7 @@ async def get_summary(
     scope: TenantScope = Depends(require_membership),
 ):
     """Get a single table summary by id."""
-    r = await db.execute(select(TableSummary).where(TableSummary.id == summary_id, TableSummary.user_id == user.id))
+    r = await db.execute(select(TableSummary).where(TableSummary.id == summary_id, TableSummary.user_id == scope.user.id))
     s = r.scalar_one_or_none()
     if not s:
         raise HTTPException(404, "Summary not found")
@@ -249,7 +249,7 @@ async def delete_summary(
     scope: TenantScope = Depends(require_membership),
 ):
     """Delete a table summary."""
-    r = await db.execute(select(TableSummary).where(TableSummary.id == summary_id, TableSummary.user_id == user.id))
+    r = await db.execute(select(TableSummary).where(TableSummary.id == summary_id, TableSummary.user_id == scope.user.id))
     s = r.scalar_one_or_none()
     if not s:
         raise HTTPException(404, "Summary not found")

--- a/backend/app/routers/template_router.py
+++ b/backend/app/routers/template_router.py
@@ -80,7 +80,7 @@ async def list_templates(
     from sqlalchemy import or_
     q = select(ReportTemplate).where(
         ReportTemplate.source_type == source.type,
-        ReportTemplate.user_id == user.id,
+        ReportTemplate.user_id == scope.user.id,
         ReportTemplate.is_builtin == False,
         or_(
             ReportTemplate.agent_id == source.agent_id,
@@ -147,8 +147,8 @@ async def run_template(
             template=template,
             source=source,
             db=db,
-            user_id=user.id,
-            organization_id=user.organization_id,
+            user_id=scope.user.id,
+            organization_id=scope.organization_id,
             filters=filters,
             date_range=date_range,
             disabled_queries=disabled_queries,
@@ -176,7 +176,7 @@ async def list_template_runs(
         .where(
             ReportTemplateRun.source_id == source_id,
             ReportTemplateRun.template_id == template_id,
-            ReportTemplateRun.user_id == user.id,
+            ReportTemplateRun.user_id == scope.user.id,
         )
         .order_by(ReportTemplateRun.created_at.desc())
         .limit(limit)
@@ -321,8 +321,8 @@ async def generate_template(
 
     tpl = ReportTemplate(
         id=str(uuid.uuid4()),
-        user_id=user.id,
-        organization_id=user.organization_id,
+        user_id=scope.user.id,
+        organization_id=scope.organization_id,
         agent_id=body.agentId,
         source_type=source.type,
         name=parsed.get("name", "AI-Generated Template"),
@@ -360,7 +360,7 @@ async def delete_template(
     r = await db.execute(
         select(ReportTemplate).where(
             ReportTemplate.id == template_id,
-            ReportTemplate.user_id == user.id,
+            ReportTemplate.user_id == scope.user.id,
             ReportTemplate.is_builtin == False,
         )
     )
@@ -495,7 +495,7 @@ async def run_template_as_report(
     # Step 1: Execute template queries
     run_result = await template_executor.execute_template(
         template=template, source=source, db=db,
-        user_id=user.id, organization_id=user.organization_id,
+        user_id=scope.user.id, organization_id=scope.organization_id,
         data_files_dir=settings.data_files_dir,
     )
 
@@ -635,7 +635,7 @@ async def run_template_as_report(
     report_id = str(uuid.uuid4())
     report = Report(
         id=report_id,
-        user_id=user.id,
+        user_id=scope.user.id,
         agent_id=body.agentId,
         source_id=source.id,
         source_name=f"{source.name} — {template.get('name', 'Template')}",
@@ -666,7 +666,7 @@ async def list_template_reports(
     """List reports generated from a specific template."""
     r = await db.execute(
         select(Report)
-        .where(Report.template_id == template_id, Report.user_id == user.id)
+        .where(Report.template_id == template_id, Report.user_id == scope.user.id)
         .order_by(Report.created_at.desc())
         .limit(20)
     )
@@ -698,7 +698,7 @@ async def update_template_queries(
     r = await db.execute(
         select(ReportTemplate).where(
             ReportTemplate.id == template_id,
-            ReportTemplate.user_id == user.id,
+            ReportTemplate.user_id == scope.user.id,
             ReportTemplate.is_builtin == False,
         )
     )
@@ -738,7 +738,7 @@ async def add_query_to_template(
     r_tpl = await db.execute(
         select(ReportTemplate).where(
             ReportTemplate.id == template_id,
-            ReportTemplate.user_id == user.id,
+            ReportTemplate.user_id == scope.user.id,
             ReportTemplate.is_builtin == False,
         )
     )
@@ -859,7 +859,7 @@ async def run_template_with_commentary(
     # Execute queries
     run_result = await template_executor.execute_template(
         template=template, source=source, db=db,
-        user_id=user.id, organization_id=user.organization_id,
+        user_id=scope.user.id, organization_id=scope.organization_id,
         filters=body.filters, date_range=body.dateRange,
         disabled_queries=body.disabledQueries,
         data_files_dir=settings.data_files_dir,
@@ -911,7 +911,7 @@ async def customize_template(
 
     # Check if user already has a customization
     q = select(ReportTemplate).where(
-        ReportTemplate.user_id == user.id,
+        ReportTemplate.user_id == scope.user.id,
         ReportTemplate.source_type == source.type,
         ReportTemplate.name == original.get("name", ""),
         ReportTemplate.is_builtin == False,
@@ -930,8 +930,8 @@ async def customize_template(
     else:
         new_tpl = ReportTemplate(
             id=str(uuid.uuid4()),
-            user_id=user.id,
-            organization_id=user.organization_id,
+            user_id=scope.user.id,
+            organization_id=scope.organization_id,
             source_type=source.type,
             name=original.get("name", ""),
             description=original.get("description", ""),
@@ -964,7 +964,7 @@ async def reset_template_customization(
         raise HTTPException(404, "Template not found")
 
     q = select(ReportTemplate).where(
-        ReportTemplate.user_id == user.id,
+        ReportTemplate.user_id == scope.user.id,
         ReportTemplate.source_type == source.type,
         ReportTemplate.name == original.get("name", ""),
         ReportTemplate.is_builtin == False,


### PR DESCRIPTION
Same bug class as #230 — the multi-tenant sed/AST refactor renamed `user` → `scope` in dependency declarations but left **40+ orphan** `user.id` / `user.email` / `user.organization_id` references in function bodies, each becoming `NameError: name 'user' is not defined` at runtime.

You hit it on **Studio → Reports / Report Summary** (`GET /api/table_summaries` → 500). Found the same bug in **7 routers** (api_keys, automl, cdp, organizations, report, summary, template) plus two helper functions that needed signatures retargeted (`automl._resolve_llm_overrides`, `cdp._get_agent_and_llm`).

## Detection
Wrote a small AST script that walks every async/sync function declaring `scope: TenantScope` without also declaring a separate `user` parameter, then flags any `user.{id,email,organization_id,role}` attribute read in its body. Re-running it after the patch returns **zero violations**.

## Verification (live)
| Endpoint | Before | After |
|---|---|---|
| `GET /api/table_summaries?agent_id=…` | 500 | 200 |
| `GET /api/reports?agent_id=…` | 500 | 200 |
| `GET /api/automl?agent_id=…` | 500 | 200 |
| `GET /api/api-keys` | 500 | 200 |
| `GET /api/organizations` | 500 | 200 |
| `GET /api/cdp/config/{agent_id}` | 500 | 200 |

No NameError lines in the backend log during the smoke run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)