### PR TITLE
fix(cors): allowlist localhost + APP_URL, drop invalid wildcard-with-credentials

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -319,9 +319,23 @@ app = FastAPI(
     title=get_settings().api_title,
     lifespan=lifespan,
 )
+# CORS: `allow_origins=["*"]` is incompatible with `allow_credentials=True`
+# per the CORS spec (browsers ignore the response when both are set), so we
+# build a concrete allowlist that covers:
+#   1. The deployment's public URL from `APP_URL` (production behind a domain).
+#   2. Any localhost port — covers Vite on 5173, the legacy 8080, the backend
+#      itself on 8000/8001, and the static FastAPI server when `dist/` is
+#      present. `127.0.0.1` is included on the same regex.
+#
+# The regex is intentionally narrow: localhost / 127.0.0.1 / 0.0.0.0 only,
+# any port, http or https. External origins must be added explicitly to
+# `APP_URL` (or extended here once we have a tenant-aware allowlist).
+_app_url = (get_settings().app_url or "").strip().rstrip("/")
+_explicit_origins = [_app_url] if _app_url else []
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_explicit_origins,
+    allow_origin_regex=r"https?://(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Frontend on `localhost:5173` was blocked from `localhost:8001` with "No Access-Control-Allow-Origin header".

**Root cause**: backend was configured with `allow_origins=["*"]` AND `allow_credentials=True`. Per CORS spec this combo is invalid — browsers drop the ACAO header when credentials are on, regardless of what the server tries to send. Effectively no CORS at all from the browser's perspective.

**Fix**: explicit allowlist.
- `APP_URL` from settings (production domain).
- Regex for `localhost` / `127.0.0.1` / `0.0.0.0` on any port (covers Vite 5173, backend 8000/8001, static FastAPI, etc.)

**Verified**:
- `Origin: http://localhost:5173` → ACAO header echoed ✅
- `Origin: https://evil.com` → no ACAO header ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)