### PR TITLE
fix(vite): stop baking VITE_API_URL; resolve backend port per-request

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,8 +22,12 @@ function resolveBackendPort(): number {
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
-  const backendPort = resolveBackendPort();
-  const backendUrl = `http://localhost:${backendPort}`;
+  // Backend URL is resolved DYNAMICALLY per request via the `router`
+  // hook below. We deliberately don't snapshot the port at config-load
+  // time anymore — if the backend restarts on a different port the
+  // proxy automatically follows without a Vite reload.
+  const dynamicBackendUrl = (): string =>
+    `http://localhost:${resolveBackendPort()}`;
 
   return {
     server: {
@@ -38,23 +42,39 @@ export default defineConfig(({ command }) => {
       strictPort: true,
       proxy: {
         "/api": {
-          target: backendUrl,
+          // Placeholder; real target comes from `router` below.
+          target: "http://localhost:8000",
           changeOrigin: true,
+          router: dynamicBackendUrl,
         },
         "/health": {
-          target: backendUrl,
+          target: "http://localhost:8000",
           changeOrigin: true,
+          router: dynamicBackendUrl,
         },
       },
     },
     plugins: [react()],
     define: {
-      // Make the backend URL available at build time for dev mode.
-      // In production (make run), the frontend is served from the backend
-      // itself so same-origin works automatically.
-      ...(command === "serve" && !process.env.VITE_API_URL
-        ? { "import.meta.env.VITE_API_URL": JSON.stringify(backendUrl) }
-        : {}),
+      // We deliberately do NOT bake `VITE_API_URL` in dev mode. The previous
+      // version snapshotted the backend port at Vite-server startup and
+      // baked `http://localhost:<port>` into every fetch URL — when the
+      // backend later moved to a different port (CLI fallback when 8000 was
+      // busy, or a stale `.backend_port` written by a side process) the
+      // frontend kept hitting the dead port and broke with CORS / network
+      // errors that were really stale-bake errors.
+      //
+      // In dev, the proxy at `server.proxy["/api"]` (above) forwards every
+      // `/api/*` request to whatever port the backend is on right now.
+      // `getApiUrl()` falls back to `window.location.origin` when
+      // `VITE_API_URL` is undefined, so relative URLs work transparently.
+      //
+      // In production (`make run`) the static `dist/` is served by FastAPI
+      // itself, so same-origin works without any env var.
+      //
+      // The escape hatch is still respected: if a developer exports
+      // `VITE_API_URL=...` themselves before running `npm run dev`, Vite
+      // will pick it up from `process.env` automatically.
     },
     resolve: {
       alias: {


### PR DESCRIPTION
**Root cause** of "the frontend keeps calling :8001" even when the backend isn't there: `vite.config.ts` snapshotted the backend port at Vite-server startup in two places:

1. `define["import.meta.env.VITE_API_URL"]` baked the URL into every fetch in the bundle.
2. `proxy["/api"].target` used the same snapshot.

When the backend moved off that port (CLI fallback, my background test scripts writing to `.backend_port`, etc.), restarting only the backend didn't help. Vite had to be restarted too — and even then it would re-snapshot whatever stale value was in the file.

**Fix**:
- Drop the `define` injection. `getApiUrl()` in `src/config.ts` already falls back to `window.location.origin` (which is `localhost:5173` in Vite dev), and the proxy routes `/api/*` to the backend.
- Use Vite's `proxy.router` hook, which is called **per request** and re-reads `backend/.backend_port` each time. Backend port changes follow automatically without any restart.

Production unchanged: `make run` serves `dist/` from FastAPI on the same origin, no proxy needed.

Escape hatch preserved: developers who export `VITE_API_URL` themselves still override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)