### PR TITLE
fix(claude-code): prefer direct Messages API when LlmConfig carries an OAuth token

### DIFF
--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -410,6 +410,22 @@ async def _claude_code_chat(messages: list[dict[str, str]], max_tokens: int, cfg
                     return t
         return None
 
+    # Path B: when the LlmConfig carries an OAuth token (i.e. the user
+    # finished the "Login with Claude" flow on Settings → LLM), prefer
+    # calling the Anthropic Messages API directly with that bearer token.
+    #
+    # The CLI binary uses its OWN internal auth (managed by `claude login`
+    # writing to ~/.claude/credentials and checked at CLI startup), and it
+    # does NOT accept the user-scoped OAuth tokens we exchange via
+    # `claude_oauth.py`. Passing one via CLAUDE_CODE_OAUTH_TOKEN makes the
+    # CLI exit 1 with "API Error: 401 Invalid authentication credentials".
+    # Routing those tokens through `_claude_code_via_api` (which sets the
+    # `anthropic-beta: oauth-2025-04-20` header and the required system
+    # prefix) is the only path that works.
+    config_oauth_token = (cfg.get("claude_code_oauth_token") or "").strip()
+    if config_oauth_token:
+        return await _claude_code_via_api(messages, max_tokens, cfg, config_oauth_token)
+
     if not claude_bin:
         oauth_token = _resolve_oauth_token()
         if oauth_token:


### PR DESCRIPTION
**The bug**: "Login with Claude" (PR #234) saves a user-scoped OAuth token (`user:inference` scope) to LlmConfig. That token works with the Messages API + the `anthropic-beta: oauth-2025-04-20` header, but **the `claude` CLI binary rejects it** — the CLI uses its own local credential store from `claude login`, not arbitrary OAuth tokens via env var.

So a user who logged in via the UI hit:
```
RuntimeError: Claude CLI exited with code 1: Failed to authenticate.
API Error: 401 {"type":"authentication_error",
                 "message":"Invalid authentication credentials"}
```

(Exactly the error you saw on Studio Summary just now — and the error extraction from PR #232 surfaced the real cause cleanly.)

**Fix**: when `LlmConfig.claude_code_oauth_token` is non-empty, route to the direct Messages API path (`_claude_code_via_api`) BEFORE attempting the CLI. The direct path already existed from PR #234 (originally only used as a CLI-missing fallback).

Decision tree:
1. Config has an OAuth token → direct API  ⬅️ new
2. No token, CLI present → CLI subprocess
3. No token, CLI missing, env/file token exists → direct API
4. Nothing → raise with install/OAuth hint

Backward-compatible: users who never used the in-app OAuth flow keep using the CLI as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)