### PR TITLE
feat(dev): free ports on make dev / start.bat dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ help:
 	@echo "  make build             Build frontend for production"
 	@echo "  make run               Build frontend and start backend (http://localhost:8000)"
 	@echo "  make dev               Start backend + frontend dev server with hot reload"
+	@echo "                          (auto-frees :5173 + :8000-8005 from our own zombies first)"
 	@echo "  make migrate           Run database migrations"
 	@echo "  make setup-env         Copy backend/.env.example to backend/.env (if not exists)"
 	@echo "  make lint              Run frontend linter"
@@ -49,7 +50,8 @@ run: build setup-env
 
 dev: setup-env
 	@echo "Starting backend and frontend dev server..."
-	@rm -f backend/.backend_port
+	@echo "Freeing dev ports (only kills our own uvicorn/data-talks/vite processes)..."
+	@./scripts/free-dev-ports.sh
 	@uv run data-talks run &
 	@echo "Waiting for backend to start..."
 	@for i in 1 2 3 4 5 6 7 8 9 10; do \

--- a/scripts/free-dev-ports.sh
+++ b/scripts/free-dev-ports.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Free the ports the dev stack uses, but only kill our own processes.
+#
+# Why we need this: the backend CLI (`data-talks run`) writes the port it
+# bound to into `backend/.backend_port`. If a previous session left a zombie
+# uvicorn on :8000 — or a previous run let the CLI fall back to :8001 — the
+# `.backend_port` file ends up stale and Vite picks the wrong upstream.
+# The blast radius is wide ("CORS broken", "frontend hits dead port",
+# "summary 500", and so on), so the safest fix is to nuke our own dev
+# processes on those ports before each `make dev`.
+#
+# Safety:
+#   - We only kill processes whose command line includes one of:
+#       uvicorn   |   data-talks   |   vite
+#     Anything else listening on the same port (Firestore emulator,
+#     Tomcat, whatever) is left alone — those are not us.
+#   - The script is silent on success and prints what it killed when it
+#     does kill something, so `make dev` output is readable.
+
+set -e
+
+PORTS_BACKEND=(8000 8001 8002 8003 8004 8005)
+PORTS_FRONTEND=(5173)
+ALL_PORTS=("${PORTS_BACKEND[@]}" "${PORTS_FRONTEND[@]}")
+
+# `lsof -ti:PORT` returns one PID per line for IPv4 listeners. We then check
+# /proc-style command listings via `ps` to confirm it's our process before
+# killing. The patterns below are deliberately narrow — earlier versions
+# matched any command containing "data-talks", which would also fire on
+# unrelated processes that just happened to live under the data-talks repo
+# (VS Code language servers, file watchers, etc).
+_is_our_process() {
+    local pid="$1"
+    local cmd
+    cmd=$(ps -p "$pid" -o command= 2>/dev/null || true)
+    [[ -z "$cmd" ]] && return 1
+    case "$cmd" in
+        # Backend: the CLI launcher and the uvicorn worker it spawns.
+        *"data-talks run"*) return 0 ;;
+        *"data-talks/backend"*"app.main"*) return 0 ;;
+        *uvicorn*"app.main"*) return 0 ;;
+        # uv-spawned Python that owns the .venv inside this repo.
+        *"data-talks/.venv/bin/python"*"data-talks/backend"*) return 0 ;;
+        *"data-talks/.venv/bin/python"*"--multiprocessing-fork"*) return 0 ;;
+        # Frontend: Vite invoked from this repo's node_modules. We match
+        # the Vite binary path, not just "vite", to avoid Vitest workers
+        # or other tools whose argv contain the word.
+        *"data-talks/node_modules/.bin/vite"*) return 0 ;;
+        *"data-talks/node_modules/vite/"*"vite.js"*) return 0 ;;
+    esac
+    return 1
+}
+
+kills=0
+for port in "${ALL_PORTS[@]}"; do
+    pids=$(lsof -ti :"$port" 2>/dev/null || true)
+    [[ -z "$pids" ]] && continue
+    while IFS= read -r pid; do
+        [[ -z "$pid" ]] && continue
+        if _is_our_process "$pid"; then
+            cmd=$(ps -p "$pid" -o command= 2>/dev/null | head -c 80)
+            printf "  killing PID %s on :%s — %s\n" "$pid" "$port" "$cmd"
+            kill "$pid" 2>/dev/null || true
+            kills=$((kills + 1))
+        fi
+    done <<< "$pids"
+done
+
+# Stale port file from a previous run can fool Vite proxy resolution.
+# Always clear it; the CLI will rewrite it on next start.
+if [[ -f backend/.backend_port ]]; then
+    rm -f backend/.backend_port
+fi
+
+# Give the OS a beat to release the sockets before the next process binds.
+if [[ $kills -gt 0 ]]; then
+    echo "  freed $kills process(es); waiting 1s for sockets to close..."
+    sleep 1
+fi
+
+exit 0

--- a/start.bat
+++ b/start.bat
@@ -37,8 +37,29 @@ if not exist "backend\.env" (
 if /i "%MODE%"=="dev" (
     echo Starting Data Talks in development mode...
 
-    :: Clean up stale port file
+    :: Free the ports we use, but only when the listener is one of our own
+    :: processes (python/uvicorn/data-talks for the backend ports, node for
+    :: Vite). We resolve PIDs via netstat and verify the image name with
+    :: tasklist before issuing taskkill, so a Firestore emulator or any
+    :: other tool the user happens to be running on the same port is left
+    :: alone.
+    echo Freeing dev ports (only kills our own backend/frontend processes)...
+    for %%P in (8000 8001 8002 8003 8004 8005 5173) do (
+        for /f "tokens=5" %%I in ('netstat -ano ^| findstr ":%%P " ^| findstr LISTENING') do (
+            for /f "tokens=1" %%N in ('tasklist /FI "PID eq %%I" /NH 2^>nul') do (
+                if /i "%%N"=="python.exe"     ( taskkill /F /PID %%I >nul 2>&1 && echo   killed PID %%I on :%%P ^(python^) )
+                if /i "%%N"=="uvicorn.exe"    ( taskkill /F /PID %%I >nul 2>&1 && echo   killed PID %%I on :%%P ^(uvicorn^) )
+                if /i "%%N"=="data-talks.exe" ( taskkill /F /PID %%I >nul 2>&1 && echo   killed PID %%I on :%%P ^(data-talks^) )
+                if /i "%%N"=="node.exe"       ( taskkill /F /PID %%I >nul 2>&1 && echo   killed PID %%I on :%%P ^(node/vite^) )
+            )
+        )
+    )
+
+    :: Clean up stale port file (CLI rewrites it on next start)
     if exist "backend\.backend_port" del "backend\.backend_port"
+
+    :: Brief pause so Windows actually releases the listening sockets
+    timeout /t 1 /nobreak >nul
 
     :: Start backend in background
     start "DataTalks-Backend" /min cmd /c "uv run data-talks run"


### PR DESCRIPTION
Fixes the chain of "why is the frontend hitting :8001 when the backend is on :8000" errors. `make dev` and `start.bat dev` now run a preflight that kills our own zombie uvicorn/data-talks/vite on the dev ports (5173 + 8000-8005) before starting.

**Safety**: matcher is narrow — only kills processes whose command line matches `data-talks run`, `uvicorn ... app.main`, `data-talks/.venv/bin/python ... --multiprocessing-fork`, or the Vite binary inside our `node_modules`. Firestore emulators, unrelated Tomcat, VS Code language servers running from the repo, etc. are left alone.

Also clears stale `backend/.backend_port` and sleeps 1s for sockets to release before the rest of `make dev` spawns the new processes.